### PR TITLE
Draft: Refactor ci tests

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -10,32 +10,43 @@ jobs:
       max-parallel: 4
       matrix:
         tox_env:
-          - py36-django111-wagtail23
-          - py36-django111-wagtail26
-          - py36-django22-wagtail23
-          - py36-django22-wagtail26
-          - py37-django111-wagtail23
-          - py37-django111-wagtail26
-          - py37-django22-wagtail23
-          - py37-django22-wagtail26
+          - py36-django22-wagtail27
+          - py36-django30-wagtail27
+          - py36-django31-wagtail27
+          - py36-django22-wagtail210
+          - py36-django30-wagtail210
+          - py36-django31-wagtail210
+          - py37-django22-wagtail27
+          - py37-django30-wagtail27
+          - py37-django31-wagtail27
+          - py37-django22-wagtail210
+          - py37-django30-wagtail210
+          - py37-django31-wagtail210
         include:
           - python-version: "3.6"
-            tox_env: py36-django111-wagtail23
+            tox_env: py36-django22-wagtail27
           - python-version: "3.6"
-            tox_env: py36-django111-wagtail26
+            tox_env: py36-django30-wagtail27
           - python-version: "3.6"
-            tox_env: py36-django22-wagtail23
+            tox_env: py36-django31-wagtail27
           - python-version: "3.6"
-            tox_env: py36-django22-wagtail26
+            tox_env: py36-django22-wagtail210
+          - python-version: "3.6"
+            tox_env: py36-django30-wagtail210
+          - python-version: "3.6"
+            tox_env: py36-django31-wagtail210
           - python-version: "3.7"
-            tox_env: py37-django111-wagtail23
+            tox_env: py37-django22-wagtail27
           - python-version: "3.7"
-            tox_env: py37-django111-wagtail26
+            tox_env: py37-django30-wagtail27
           - python-version: "3.7"
-            tox_env: py37-django22-wagtail23
+            tox_env: py37-django31-wagtail27
           - python-version: "3.7"
-            tox_env: py37-django22-wagtail26
-
+            tox_env: py37-django22-wagtail210
+          - python-version: "3.7"
+            tox_env: py37-django30-wagtail210
+          - python-version: "3.7"
+            tox_env: py37-django31-wagtail210
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,47 @@
 ---
 dist: xenial
-sudo: false
+os: linux
 language: python
 
 addons:
-  postgresql: "9.4"
+  postgresql: "10"
 
 # LOL!
-matrix:
+jobs:
   include:
     - python: 3.6
-      env: TOXENV=py36-django111-wagtail23
+      env: TOXENV=py36-django22-wagtail27
     - python: 3.6
-      env: TOXENV=py36-django111-wagtail26
+      env: TOXENV=py36-django30-wagtail27
     - python: 3.6
-      env: TOXENV=py36-django22-wagtail23
+      env: TOXENV=py36-django31-wagtail27
     - python: 3.6
-      env: TOXENV=py36-django22-wagtail26
-
+      env: TOXENV=py36-django22-wagtail210
+    - python: 3.6
+      env: TOXENV=py36-django30-wagtail210
+    - python: 3.6
+      env: TOXENV=py36-django31-wagtail210
     - python: 3.7
-      env: TOXENV=py37-django111-wagtail23
+      env: TOXENV=py37-django22-wagtail27
     - python: 3.7
-      env: TOXENV=py37-django111-wagtail26
+      env: TOXENV=py37-django30-wagtail27
     - python: 3.7
-      env: TOXENV=py37-django22-wagtail23
+      env: TOXENV=py37-django31-wagtail27
     - python: 3.7
-      env: TOXENV=py37-django22-wagtail26
-
+      env: TOXENV=py37-django22-wagtail210
+    - python: 3.7
+      env: TOXENV=py37-django30-wagtail210
+    - python: 3.7
+      env: TOXENV=py37-django31-wagtail210
   allow_failures:
     - python: 3.6
       env: TOXENV=lint
 
-
 install:
   - pip install tox codecov
 
-
 script:
   - tox
-
 
 after_success:
   - tox -e coverage-report

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,12 @@ docs_require = [
 ]
 
 tests_require = [
-    'pytest==5.0.1',
-    'pytest-django==3.5.1',
+    'pytest==6.0.1',
+    'pytest-django==3.9.0',
     'pytest-cov==2.7.1',
     'pytest-pythonpath==0.7.3',
     'psycopg2>=2.3.1',
     'coverage==4.5.3',
-
     'isort==4.3.21',
     'flake8==3.7.8',
     'flake8-blind-except==0.1.1',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
-envlist = py{36,37}-django{111,22}-wagtail{23,26}
+envlist = py{36,37}-django{22,30,31}-wagtail{27,210}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 deps =
-    django111: django>=1.11,<1.12
     django22: django>=2.2,<2.3
-    wagtail23: wagtail>=2.3,<2.4
-    wagtail26: wagtail>=2.6,<2.7
+    django30: django>=3.0,<3.1
+    django31: django>=3.1,<3.2
+    wagtail27: wagtail>=2.7,<2.8
+    wagtail210: wagtail>=2.10,<2.11
 
 [testenv:coverage-report]
 basepython = python3.6


### PR DESCRIPTION
In this PR I have updated both the tox config, the travis CI config and github actions, I have done the following:

- Dropped Django 1 support
- Only used supported Wagtail versions (2.7 and 2.10)
- Only used supported Django versions (3.1, 3.0 and 2.2)

We should probably drop Travis in favor of github actions, I have chosen not to do this in this PR without discussion.

I'm also looking at optimizing the CI bit, its a lot of repetition taken place right now, we should be able to go from explicit to setting an array with ignore-rules.