### PR TITLE
Drop incompatible test targets

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -27,18 +27,14 @@ jobs:
         tox_env:
           # Test 2.2 (LTS), 3.1 (Latest) releases for Python 3.6, 3.7
           - py36-django22-wagtail27
-          - py36-django31-wagtail27
           - py36-django22-wagtail210
           - py36-django31-wagtail210
           - py37-django22-wagtail27
-          - py37-django31-wagtail27
           - py37-django22-wagtail210
           - py37-django31-wagtail210
 
           # Test all versions for Python 3.8
           - py38-django22-wagtail27
-          - py38-django30-wagtail27
-          - py38-django31-wagtail27
           - py38-django22-wagtail210
           - py38-django30-wagtail210
           - py38-django31-wagtail210
@@ -48,8 +44,6 @@ jobs:
           - python-version: "3.6"
             tox_env: py36-django22-wagtail27
           - python-version: "3.6"
-            tox_env: py36-django31-wagtail27
-          - python-version: "3.6"
             tox_env: py36-django22-wagtail210
           - python-version: "3.6"
             tox_env: py36-django31-wagtail210
@@ -57,18 +51,12 @@ jobs:
           - python-version: "3.7"
             tox_env: py37-django22-wagtail27
           - python-version: "3.7"
-            tox_env: py37-django31-wagtail27
-          - python-version: "3.7"
             tox_env: py37-django22-wagtail210
           - python-version: "3.7"
             tox_env: py37-django31-wagtail210
 
           - python-version: "3.8"
             tox_env: py38-django22-wagtail27
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail27
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail27
           - python-version: "3.8"
             tox_env: py38-django22-wagtail210
           - python-version: "3.8"


### PR DESCRIPTION
(WIP) This fixes the issue with Django 3+ is not supported by Wagtail 2.7, my plan is also to update test targets against the current Wagtail versions. (Will come in upcoming commit)

