### PR TITLE
Add factory-boy 3.2 support, refactor test targets and drop factory-boy<2.12

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -24,75 +23,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        tox_env:
-          # Test 2.2 (LTS), 3.1 (Latest) releases for Python 3.6, 3.7
-          - py36-django22-wagtail27-factoryboy212
-          - py36-django22-wagtail27-factoryboy32
-          - py36-django22-wagtail210-factoryboy212
-          - py36-django22-wagtail210-factoryboy32
-          - py36-django31-wagtail210-factoryboy212
-          - py36-django31-wagtail210-factoryboy32
-          - py37-django22-wagtail27-factoryboy212
-          - py37-django22-wagtail27-factoryboy32
-          - py37-django22-wagtail210-factoryboy212
-          - py37-django22-wagtail210-factoryboy32
-          - py37-django31-wagtail210-factoryboy212
-          - py37-django31-wagtail210-factoryboy32
-
-          # Test all versions for Python 3.8
-          - py38-django22-wagtail27-factoryboy212
-          - py38-django22-wagtail27-factoryboy32
-          - py38-django22-wagtail210-factoryboy212
-          - py38-django22-wagtail210-factoryboy32
-          - py38-django30-wagtail210-factoryboy212
-          - py38-django30-wagtail210-factoryboy32
-          - py38-django31-wagtail210-factoryboy212
-          - py38-django31-wagtail210-factoryboy32
-
-
-        include:
-          - python-version: "3.6"
-            tox_env: py36-django22-wagtail27-factoryboy212
-          - python-version: "3.6"
-            tox_env: py36-django22-wagtail27-factoryboy32
-          - python-version: "3.6"
-            tox_env: py36-django22-wagtail210-factoryboy212
-          - python-version: "3.6"
-            tox_env: py36-django22-wagtail210-factoryboy32
-          - python-version: "3.6"
-            tox_env: py36-django31-wagtail210-factoryboy212
-          - python-version: "3.6"
-            tox_env: py36-django31-wagtail210-factoryboy32
-
-          - python-version: "3.7"
-            tox_env: py37-django22-wagtail27-factoryboy212
-          - python-version: "3.7"
-            tox_env: py37-django22-wagtail27-factoryboy32
-          - python-version: "3.7"
-            tox_env: py37-django22-wagtail210-factoryboy212
-          - python-version: "3.7"
-            tox_env: py37-django22-wagtail210-factoryboy32
-          - python-version: "3.7"
-            tox_env: py37-django31-wagtail210-factoryboy212
-          - python-version: "3.7"
-            tox_env: py37-django31-wagtail210-factoryboy32
-
-          - python-version: "3.8"
-            tox_env: py38-django22-wagtail27-factoryboy212
-          - python-version: "3.8"
-            tox_env: py38-django22-wagtail27-factoryboy32
-          - python-version: "3.8"
-            tox_env: py38-django22-wagtail210-factoryboy212
-          - python-version: "3.8"
-            tox_env: py38-django22-wagtail210-factoryboy32
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail210-factoryboy212
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail210-factoryboy32
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail210-factoryboy212
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail210-factoryboy32
+        python-version: [3.6, 3.7, 3.8]
+        django: [22, 31]
+        wagtail: [27, 210]
+        factoryboy: [212, 32]
+        exclude:
+          - wagtail: 27
+            django: 31
 
     steps:
     - uses: actions/checkout@v1
@@ -108,5 +45,6 @@ jobs:
         TEST_DB_NAME: wagtail_factories
         TEST_DB_USER: wagtail_factories
         TEST_DB_PASSWORD: secret
+        TOX_ENV: py${{ matrix.python-version}}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}
       run: |
-        tox -e ${{ matrix.tox_env }}
+        tox -e $TOX_ENV

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -23,11 +23,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        django: [22, 31]
-        wagtail: [27, 210]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        django: [22, 30, 31]
+        wagtail: [27, 211]
         factoryboy: [212, 32]
         exclude:
+          - wagtail: 27
+            django: 30
           - wagtail: 27
             django: 31
 

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -27,18 +27,14 @@ jobs:
         tox_env:
           # Test 2.2 (LTS), 3.1 (Latest) releases for Python 3.6, 3.7
           - py36-django22-wagtail27
-          - py36-django31-wagtail27
           - py36-django22-wagtail210
           - py36-django31-wagtail210
           - py37-django22-wagtail27
-          - py37-django31-wagtail27
           - py37-django22-wagtail210
           - py37-django31-wagtail210
 
           # Test all versions for Python 3.8
           - py38-django22-wagtail27
-          - py38-django30-wagtail27
-          - py38-django31-wagtail27
           - py38-django22-wagtail210
           - py38-django30-wagtail210
           - py38-django31-wagtail210
@@ -48,8 +44,6 @@ jobs:
           - python-version: "3.6"
             tox_env: py36-django22-wagtail27
           - python-version: "3.6"
-            tox_env: py36-django31-wagtail27
-          - python-version: "3.6"
             tox_env: py36-django22-wagtail210
           - python-version: "3.6"
             tox_env: py36-django31-wagtail210
@@ -57,18 +51,12 @@ jobs:
           - python-version: "3.7"
             tox_env: py37-django22-wagtail27
           - python-version: "3.7"
-            tox_env: py37-django31-wagtail27
-          - python-version: "3.7"
             tox_env: py37-django22-wagtail210
           - python-version: "3.7"
             tox_env: py37-django31-wagtail210
 
           - python-version: "3.8"
             tox_env: py38-django22-wagtail27
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail27
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail27
           - python-version: "3.8"
             tox_env: py38-django22-wagtail210
           - python-version: "3.8"

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -23,7 +23,11 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version:
+          - {version: 3.6, tox: 36}
+          - {version: 3.7, tox: 37}
+          - {version: 3.8, tox: 38}
+          - {version: 3.9, tox: 39}
         django: [22, 30, 31]
         wagtail: [27, 211]
         factoryboy: [212, 32]
@@ -38,7 +42,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version.version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox
@@ -47,6 +51,6 @@ jobs:
         TEST_DB_NAME: wagtail_factories
         TEST_DB_USER: wagtail_factories
         TEST_DB_PASSWORD: secret
-        TOX_ENV: py${{ matrix.python-version}}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}
+        TOX_ENV: "py${{ matrix.python-version.tox }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}"
       run: |
         tox -e $TOX_ENV

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -26,43 +26,73 @@ jobs:
       matrix:
         tox_env:
           # Test 2.2 (LTS), 3.1 (Latest) releases for Python 3.6, 3.7
-          - py36-django22-wagtail27
-          - py36-django22-wagtail210
-          - py36-django31-wagtail210
-          - py37-django22-wagtail27
-          - py37-django22-wagtail210
-          - py37-django31-wagtail210
+          - py36-django22-wagtail27-factoryboy212
+          - py36-django22-wagtail27-factoryboy32
+          - py36-django22-wagtail210-factoryboy212
+          - py36-django22-wagtail210-factoryboy32
+          - py36-django31-wagtail210-factoryboy212
+          - py36-django31-wagtail210-factoryboy32
+          - py37-django22-wagtail27-factoryboy212
+          - py37-django22-wagtail27-factoryboy32
+          - py37-django22-wagtail210-factoryboy212
+          - py37-django22-wagtail210-factoryboy32
+          - py37-django31-wagtail210-factoryboy212
+          - py37-django31-wagtail210-factoryboy32
 
           # Test all versions for Python 3.8
-          - py38-django22-wagtail27
-          - py38-django22-wagtail210
-          - py38-django30-wagtail210
-          - py38-django31-wagtail210
+          - py38-django22-wagtail27-factoryboy212
+          - py38-django22-wagtail27-factoryboy32
+          - py38-django22-wagtail210-factoryboy212
+          - py38-django22-wagtail210-factoryboy32
+          - py38-django30-wagtail210-factoryboy212
+          - py38-django30-wagtail210-factoryboy32
+          - py38-django31-wagtail210-factoryboy212
+          - py38-django31-wagtail210-factoryboy32
 
 
         include:
           - python-version: "3.6"
-            tox_env: py36-django22-wagtail27
+            tox_env: py36-django22-wagtail27-factoryboy212
           - python-version: "3.6"
-            tox_env: py36-django22-wagtail210
+            tox_env: py36-django22-wagtail27-factoryboy32
           - python-version: "3.6"
-            tox_env: py36-django31-wagtail210
+            tox_env: py36-django22-wagtail210-factoryboy212
+          - python-version: "3.6"
+            tox_env: py36-django22-wagtail210-factoryboy32
+          - python-version: "3.6"
+            tox_env: py36-django31-wagtail210-factoryboy212
+          - python-version: "3.6"
+            tox_env: py36-django31-wagtail210-factoryboy32
 
           - python-version: "3.7"
-            tox_env: py37-django22-wagtail27
+            tox_env: py37-django22-wagtail27-factoryboy212
           - python-version: "3.7"
-            tox_env: py37-django22-wagtail210
+            tox_env: py37-django22-wagtail27-factoryboy32
           - python-version: "3.7"
-            tox_env: py37-django31-wagtail210
+            tox_env: py37-django22-wagtail210-factoryboy212
+          - python-version: "3.7"
+            tox_env: py37-django22-wagtail210-factoryboy32
+          - python-version: "3.7"
+            tox_env: py37-django31-wagtail210-factoryboy212
+          - python-version: "3.7"
+            tox_env: py37-django31-wagtail210-factoryboy32
 
           - python-version: "3.8"
-            tox_env: py38-django22-wagtail27
+            tox_env: py38-django22-wagtail27-factoryboy212
           - python-version: "3.8"
-            tox_env: py38-django22-wagtail210
+            tox_env: py38-django22-wagtail27-factoryboy32
           - python-version: "3.8"
-            tox_env: py38-django30-wagtail210
+            tox_env: py38-django22-wagtail210-factoryboy212
           - python-version: "3.8"
-            tox_env: py38-django31-wagtail210
+            tox_env: py38-django22-wagtail210-factoryboy32
+          - python-version: "3.8"
+            tox_env: py38-django30-wagtail210-factoryboy212
+          - python-version: "3.8"
+            tox_env: py38-django30-wagtail210-factoryboy32
+          - python-version: "3.8"
+            tox_env: py38-django31-wagtail210-factoryboy212
+          - python-version: "3.8"
+            tox_env: py38-django31-wagtail210-factoryboy32
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "factory-boy>=2.12.0",
-    "wagtail>=2.0",
+    "wagtail>=2.7",
 ]
 
 docs_require = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 from setuptools import find_packages, setup
 
 install_requires = [
-    "factory-boy>=2.8.0",
+    "factory-boy>=2.12.0",
     "wagtail>=2.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-django{22,30,31}-wagtail{27,210}
+envlist = py{36,37,38}-django{22,30,31}-wagtail{27,210}-factoryboy{212,32}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -18,6 +18,8 @@ deps =
     django31: django>=3.1,<3.2
     wagtail27: wagtail>=2.7,<2.8
     wagtail210: wagtail>=2.10,<2.11
+    factoryboy212: factory-boy>=2.12,<3.0
+    factoryboy32: factory-boy>=3.2,<3.3
 
 [testenv:coverage-report]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9}-django{22,30,31}-wagtail{27,211}-factoryboy{212,32}
+envlist = py{36,37,38,39}-django{22,30,31}-wagtail{27,211}-factoryboy{212,32}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8}-django{22,30,31}-wagtail{27,210}-factoryboy{212,32}
+envlist = py{3.6,3.7,3.8,3.9}-django{22,30,31}-wagtail{27,211}-factoryboy{212,32}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -17,7 +17,7 @@ deps =
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
     wagtail27: wagtail>=2.7,<2.8
-    wagtail210: wagtail>=2.10,<2.11
+    wagtail211: wagtail>=2.11,<2.12
     factoryboy212: factory-boy>=2.12,<3.0
     factoryboy32: factory-boy>=3.2,<3.3
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-django{22,30,31}-wagtail{27,210}-factoryboy{212,32}
+envlist = py{3.6,3.7,3.8}-django{22,30,31}-wagtail{27,210}-factoryboy{212,32}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}


### PR DESCRIPTION
This PR includes the following:

- [x] Add factory-boy 3.2 support (fixes: https://github.com/wagtail/wagtail-factories/issues/38)
- [x] Drop incompatible test targets in package test suite (included py3.9, updated LTS for django/wagtail)
- [x] Include factory-boy v2 and v3 in CI tests
- [x] Update minimum required factory-boy version (the current 2.8 versions breaks in tests and is about 4 years old), I've updated it to 2.12 to still get v2 compatibility while keeping all the components working
- [x] Updated minimum required Wagtail version, from 2.0 to 2.7 (which is the latest LTS)
- [x] Simplify test matrix in github actions by excluding combinations rather than including

Feedback is much appreciated!

(This is a continuation of https://github.com/wagtail/wagtail-factories/pull/37)