### PR TITLE
Support Wagtail 3.0

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -51,6 +51,6 @@ jobs:
         TEST_DB_NAME: wagtail_factories
         TEST_DB_USER: wagtail_factories
         TEST_DB_PASSWORD: secret
-        TOX_ENV: "python${{ matrix.python-version.tox }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}"
+        TOX_ENV: "py${{ matrix.python-version.tox }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}"
       run: |
         tox -e $TOX_ENV

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -1,6 +1,6 @@
 name: Python Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -24,16 +24,18 @@ jobs:
       max-parallel: 4
       matrix:
         python-version:
-          - {version: 3.6, tox: 36}
           - {version: 3.7, tox: 37}
           - {version: 3.8, tox: 38}
           - {version: 3.9, tox: 39}
-        django: [22, 31, 32]
-        wagtail: [211, 213]
-        factoryboy: [212, 32]
+          - {version: '3.10', tox: 310}
+        django: [32, 40]
+        wagtail: [215, 216, 30]
+        factoryboy: [32]
         exclude:
-          - wagtail: 211
-            django: 32
+          - wagtail: 215
+            django: 40
+          - python-version: {version: 3.7, tox: 37}
+            django: 40
 
     steps:
     - uses: actions/checkout@v1
@@ -49,6 +51,6 @@ jobs:
         TEST_DB_NAME: wagtail_factories
         TEST_DB_USER: wagtail_factories
         TEST_DB_PASSWORD: secret
-        TOX_ENV: "py${{ matrix.python-version.tox }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}"
+        TOX_ENV: "python${{ matrix.python-version.tox }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}"
       run: |
         tox -e $TOX_ENV

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+Unreleased
+=====
+ - Add support for Wagtail 3.0 and drop support for all Wagtail versions
+   before 2.15
+ - Add support for Django 4.0
+ - Add support for Python 3.10
+ - Removed support for Python 3.6
+ - Removed support for Django 2.2 and 3.1
+ - Removed support for factory boy <3.2
+
 2.0.1
 =====
  - Updating to support Factory Boy 3.0

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import re
 from setuptools import find_packages, setup
 
 install_requires = [
-    "factory-boy>=2.12.0",
-    "wagtail>=2.11",
+    "factory-boy>=3.2",
+    "wagtail>=2.15",
 ]
 
 docs_require = [
@@ -12,16 +12,16 @@ docs_require = [
 ]
 
 tests_require = [
-    "pytest==6.0.1",
-    "pytest-django==3.9.0",
-    "pytest-cov==2.7.1",
+    "pytest==6.2.5",
+    "pytest-django==4.5.0",
+    "pytest-cov==3.0.0",
     "pytest-pythonpath==0.7.3",
     "psycopg2>=2.3.1",
-    "coverage==4.5.3",
-    "isort==4.3.21",
-    "flake8==3.7.8",
+    "coverage==6.0",
+    "isort==5.10.0",
+    "flake8==4.0.0",
     "flake8-blind-except==0.1.1",
-    "flake8-debugger==3.1.0",
+    "flake8-debugger==4.1.2",
 ]
 
 with open("README.rst") as fh:
@@ -54,17 +54,18 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Framework :: Wagtail",
+        "Framework :: Wagtail :: 2",
+        "Framework :: Wagtail :: 3",
     ],
     zip_safe=False,
 )

--- a/src/wagtail_factories/blocks.py
+++ b/src/wagtail_factories/blocks.py
@@ -2,11 +2,15 @@ from collections import defaultdict
 
 import factory
 from factory.declarations import ParameteredAttribute
-from wagtail.core import blocks
 from wagtail.images.blocks import ImageChooserBlock
 
-from wagtail_factories.factories import ImageFactory
+try:
+    from wagtail import blocks
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core import blocks
 
+from wagtail_factories.factories import ImageFactory
 
 __all__ = [
     "CharBlockFactory",
@@ -88,11 +92,6 @@ class ListBlockFactory(factory.SubFactory):
             item = subfactory(**index_params)
             retval.append(item)
         return retval
-
-    def generate(self, step, params):
-        # This method was used in factory-boy <3.2 instead of evaluate(), it
-        # could be removed when we stop to support this older version.
-        return self.evaluate(None, step, params)
 
 
 class BlockFactory(factory.Factory):

--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -4,19 +4,17 @@ import factory
 from django.utils.text import slugify
 from factory import errors, utils
 from factory.declarations import ParameteredAttribute
-from wagtail import VERSION as WAGTAIL_VERSION
-from wagtail.core.models import Collection, Page, Site
 from wagtail.images import get_image_model
 
 try:
-    from factory.django import DjangoModelFactory
+    from wagtail.models import Collection, Page, Site
 except ImportError:
-    from factory import DjangoModelFactory
+    # Wagtail<3.0
+    from wagtail.core.models import Collection, Page, Site
 
-if WAGTAIL_VERSION >= (2, 8):
-    from wagtail.documents import get_document_model
-else:
-    from wagtail.documents.models import get_document_model
+from factory.django import DjangoModelFactory
+
+from wagtail.documents import get_document_model
 
 __all__ = [
     "CollectionFactory",

--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -13,7 +13,6 @@ except ImportError:
     from wagtail.core.models import Collection, Page, Site
 
 from factory.django import DjangoModelFactory
-
 from wagtail.documents import get_document_model
 
 __all__ = [

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -2,8 +2,6 @@ import os
 
 from wagtail import VERSION as WAGTAIL_VERSION
 
-MIDDLEWARE_CLASSES = []
-
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
@@ -27,6 +25,27 @@ DATABASES = {
 }
 
 INSTALLED_APPS = [
+    # Wagtail packages
+    "wagtail.contrib.styleguide",
+    "wagtail.contrib.sitemaps",
+    "wagtail.contrib.routable_page",
+    "wagtail.contrib.frontend_cache",
+    "wagtail.contrib.search_promotions",
+    "wagtail.contrib.settings",
+    "wagtail.contrib.modeladmin",
+    "wagtail.contrib.table_block",
+    "wagtail.contrib.forms",
+    "wagtail.search",
+    "wagtail.embeds",
+    "wagtail.images",
+    "wagtail.sites",
+    "wagtail.users",
+    "wagtail.snippets",
+    "wagtail.documents",
+    "wagtail.admin",
+    "wagtail.api.v2",
+    "wagtail" if WAGTAIL_VERSION >= (3, 0) else "wagtail.core",
+    # Other packages
     "taggit",
     "rest_framework",
     "django.contrib.admin",
@@ -39,53 +58,22 @@ INSTALLED_APPS = [
     "tests.testapp",
 ]
 
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+]
 
-if WAGTAIL_VERSION < (2, 0):
-    INSTALLED_APPS = [
-        "wagtail.contrib.wagtailstyleguide",
-        "wagtail.contrib.wagtailsitemaps",
-        "wagtail.contrib.wagtailroutablepage",
-        "wagtail.contrib.wagtailfrontendcache",
-        "wagtail.contrib.wagtailapi",
-        "wagtail.contrib.wagtailsearchpromotions",
-        "wagtail.contrib.settings",
-        "wagtail.contrib.modeladmin",
-        "wagtail.contrib.table_block",
-        "wagtail.wagtailforms",
-        "wagtail.wagtailsearch",
-        "wagtail.wagtailembeds",
-        "wagtail.wagtailimages",
-        "wagtail.wagtailsites",
-        "wagtail.wagtailusers",
-        "wagtail.wagtailsnippets",
-        "wagtail.wagtaildocs",
-        "wagtail.wagtailadmin",
-        "wagtail.api.v2",
-        "wagtail.wagtailcore",
-    ] + INSTALLED_APPS
-else:
-    INSTALLED_APPS = [
-        "wagtail.contrib.styleguide",
-        "wagtail.contrib.sitemaps",
-        "wagtail.contrib.routable_page",
-        "wagtail.contrib.frontend_cache",
-        "wagtail.contrib.search_promotions",
-        "wagtail.contrib.settings",
-        "wagtail.contrib.modeladmin",
-        "wagtail.contrib.table_block",
-        "wagtail.contrib.forms",
-        "wagtail.search",
-        "wagtail.embeds",
-        "wagtail.images",
-        "wagtail.sites",
-        "wagtail.users",
-        "wagtail.snippets",
-        "wagtail.documents",
-        "wagtail.admin",
-        "wagtail.api.v2",
-        "wagtail.core",
-    ] + INSTALLED_APPS
-
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.search.backends.database',
+    }
+}
 
 TEMPLATES = [
     {

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,11 +1,16 @@
 from collections import OrderedDict
 
 import pytest
-from wagtail.core.blocks import StructValue
 from wagtail.images.models import Image
 
 import wagtail_factories
 from tests.testapp.factories import MyBlockFactory, MyTestPageWithStreamFieldFactory
+
+try:
+    from wagtail.blocks import StructValue
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core.blocks import StructValue
 
 
 @pytest.mark.django_db

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -125,7 +125,7 @@ def test_custom_page_streamfield_data_complex():
 
     assert page.body[3].block_type == "image"
     assert page.body[3].value == image
-    
+
     content = str(page.body)
     assert "block-image" in content
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,8 +1,13 @@
 import pytest
-from wagtail.core.models import Page, Site
 
 import wagtail_factories
 from tests.testapp.factories import MyTestPageFactory, MyTestPageGetOrCreateFactory
+
+try:
+    from wagtail.models import Page, Site
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core.models import Page, Site
 
 
 @pytest.mark.django_db

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -6,8 +6,9 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 try:
-    from wagtail.wagtailcore import blocks, fields
+    from wagtail import blocks, fields
 except ImportError:
+    # Wagtail<3.0
     from wagtail.core import blocks, fields
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,6 +1,20 @@
-from wagtail.core import blocks
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Page
+try:
+    from wagtail import blocks
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core import blocks
+
+try:
+    from wagtail.fields import StreamField
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core.fields import StreamField
+
+try:
+    from wagtail.models import Page
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core.models import Page
 from wagtail.images.blocks import ImageChooserBlock
 
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,12 @@
-from django.conf.urls import include, url
-from wagtail.core import urls as wagtail_urls
+from django.urls import include, path
 
-urlpatterns = []
+try:
+    from wagtail import urls as wagtail_urls
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core import urls as wagtail_urls
 
-urlpatterns += [url(r"^", include(wagtail_urls))]
+
+urlpatterns = [
+    path("", include(wagtail_urls)),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py{36,37,38,39}-django{22,31,32}-wagtail{211,213}-factoryboy{212,32}
+envlist =
+    python{37,38,39,310}-django32-wagtail{215,216}-factoryboy32
+    python{38,39,310}-django{32,40}-wagtail{216,30}-factoryboy32
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -11,14 +13,18 @@ passenv =
     TEST_DB_HOST
     TEST_DB_PORT
 
+basepython =
+    python37: python3.7
+    python38: python3.8
+    python39: python3.9
+    python310: python3.10
 
 deps =
-    django22: django>=2.2,<2.3
-    django31: django>=3.1,<3.2
     django32: django>=3.2,<3.3
-    wagtail211: wagtail>=2.11,<2.12
-    wagtail213: wagtail>=2.13,<2.14
-    factoryboy212: factory-boy>=2.12,<3.0
+    django40: django>=4,<5
+    wagtail215: wagtail>=2.15,<2.16
+    wagtail216: wagtail>=2.16,<3.0
+    wagtail30: wagtail>=3.0,<4.0
     factoryboy32: factory-boy>=3.2,<3.3
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
+minversion = 3.14.6
 envlist =
-    python{37,38,39,310}-django32-wagtail{215,216}-factoryboy32
-    python{38,39,310}-django{32,40}-wagtail{216,30}-factoryboy32
+    py{37,38,39,310}-django32-wagtail{215,216}-factoryboy32
+    py{38,39,310}-django40-wagtail{216,30}-factoryboy32
+    coverage-report
+    lint
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -12,13 +15,6 @@ passenv =
     TEST_DB_PASSWORD
     TEST_DB_HOST
     TEST_DB_PORT
-
-basepython =
-    python37: python3.7
-    python38: python3.8
-    python39: python3.9
-    python310: python3.10
-
 deps =
     django32: django>=3.2,<3.3
     django40: django>=4,<5
@@ -36,10 +32,9 @@ commands =
     coverage combine
     coverage report
 
-
 [testenv:lint]
 basepython = python3.7
 deps = flake8
 commands =
     flake8 src tests setup.py
-    isort -q --recursive --diff src/ tests/
+    isort --recursive --check-only --diff src tests


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/support-team/tickets/491

Make the current package support Wagtail 3.0. 

I selected some changes from this MR, then added Wagtail 3.0 changes
https://github.com/wagtail/wagtail-factories/pull/50
- Drop Python 3.6 (EOL)
- Drop Django 2.2 (EOL), 3.1 (EOL)
- Drop Wagtail 2.11 (EOL), 2.13 (EOL), 2.14 (EOL)
- Drop factory_boy <3.2
- Add Python 3.10 
- Add Django 4.0
- Add Wagtail 2.15 LTS and 2.16 and 3.0
