### PR TITLE
Add TestCase that automatically test PageFactory subclasses 

### DIFF
--- a/src/wagtail_factories/autotest.py
+++ b/src/wagtail_factories/autotest.py
@@ -1,0 +1,75 @@
+import os
+
+from django.contrib.auth import get_user_model
+from django.http import HttpRequest
+from django.test import TestCase
+from wagtail.models import Page
+from wagtail.admin.views.pages import EditView
+
+import wagtail_factories
+
+
+class PageFeaturesTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = get_user_model().objects.create_superuser("superuser")
+        cls.default_request = cls.get_request("/")
+
+    @classmethod
+    def get_request(cls, path: str, method: str = "GET") -> HttpRequest:
+        request = HttpRequest()
+        request.method = method
+        request.path = path
+        request.user = get_user_model().objects.create_superuser("superuser")
+
+    def assertCanRenderPageWithoutErrors(self, page: Page, route_path: str = "/"):
+        full_path = os.path.join(page.get_url(self.default_request), route_path)
+        request = self.get_request(full_path)
+        try:
+            view, args, kwargs = page.resolve_subpage(route_path)
+        except AttributeError:
+            page.serve(request)
+        else:
+            page.serve(request, view, args, kwargs)
+
+    def assertCanEditPageWithoutErrors(self, page: Page):
+        path = f"/admin/pages/{page.id}/edit/"
+        request = self.get_request(path)
+        EditView.as_view()(request, page.id)
+        post_request = self.get_request(path, method="POST")
+        EditView.as_view()(post_request, page.id)
+
+    def assertCanPreviewPageWithoutErrors(self, page: Page, preview_mode: str = ""):
+        path = f"/admin/pages/{page.id}/edit/preview/?mode={preview_mode}"
+        request = self.get_request(path)
+        preview_request = page.make_preview_request(request, preview_mode)
+        page.serve_preview(preview_request, preview_mode)
+
+
+class PageAutoTestCase(PageFeaturesTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.factories_to_test = [
+            f for f in wagtail_factories.get_page_factories() if f._meta.autotest
+        ]
+
+    def test_can_render_pages_without_errors(self):
+        for factory in self.factories_to_test:
+            page = factory()
+            for path in page.get_route_paths(page):
+                with self.subTest(f"Page type: {type(page)}, Route: {path}"):
+                    self.assertCanRenderPageWithoutErrors(page, path)
+
+    def test_can_edit_pages_without_errors(self):
+        for factory in self.factories_to_test:
+            page = factory()
+            with self.subTest(f"Page type: {type(page)}"):
+                self.assertCanEditPageWithoutErrors(page)
+
+    def test_can_preview_pages_without_errors(self):
+        for factory in self.factories_to_test:
+            page = factory()
+            for mode, label in page.preview_modes:
+                with self.subTest(f"Page type: {type(page)}, Mode: {label}"):
+                    self.assertCanPreviewPageWithoutErrors(page, mode)

--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -3,6 +3,7 @@ import logging
 import factory
 from django.utils.text import slugify
 from factory import errors, utils
+from factory.base import FactoryOptions, OptionDefault
 from factory.declarations import ParameteredAttribute
 from wagtail.images import get_image_model
 
@@ -131,12 +132,23 @@ class PageFactoryMetaClass(FactoryMetaClass):
         return new_class
 
 
+class PageFactoryOptions(FactoryOptions):
+    def _build_default_options(self):
+        return super()._build_default_options() + [
+            OptionDefault("autotest", True, inherit=False),
+        ]
+
+
 class PageFactory(MP_NodeFactory, metaclass=PageFactoryMetaClass):
+
     title = "Test page"
     slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
 
+    _options_class = PageFactoryOptions
+
     class Meta:
         model = Page
+        autotest = False
 
 
 class CollectionMemberFactory(DjangoModelFactory):

--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -12,10 +12,12 @@ except ImportError:
     # Wagtail<3.0
     from wagtail.core.models import Collection, Page, Site
 
+from factory.base import FactoryMetaClass
 from factory.django import DjangoModelFactory
 from wagtail.documents import get_document_model
 
 __all__ = [
+    "get_page_factories",
     "CollectionFactory",
     "ImageFactory",
     "PageFactory",
@@ -23,6 +25,13 @@ __all__ = [
     "DocumentFactory",
 ]
 logger = logging.getLogger(__file__)
+
+
+PAGE_FACTORIES = []
+
+
+def get_page_factories():
+    return PAGE_FACTORIES
 
 
 class ParentNodeFactory(ParameteredAttribute):
@@ -115,7 +124,14 @@ class CollectionFactory(MP_NodeFactory):
         model = Collection
 
 
-class PageFactory(MP_NodeFactory):
+class PageFactoryMetaClass(FactoryMetaClass):
+    def __new__(mcs, class_name, bases, attrs):
+        new_class = super().__new__(mcs, class_name, bases, attrs)
+        PAGE_FACTORIES.append(new_class)
+        return new_class
+
+
+class PageFactory(MP_NodeFactory, metaclass=PageFactoryMetaClass):
     title = "Test page"
     slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
 

--- a/tests/test_autotest.py
+++ b/tests/test_autotest.py
@@ -1,0 +1,1 @@
+from wagtail_factories.autotest import PageAutoTestCase  # noqa

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,7 +1,11 @@
 import pytest
 
 import wagtail_factories
-from tests.testapp.factories import MyTestPageFactory, MyTestPageGetOrCreateFactory
+from tests.testapp.factories import (
+    MyTestPageFactory,
+    MyTestPageGetOrCreateFactory,
+    MyTestPageWithStreamFieldFactory,
+)
 
 try:
     from wagtail.models import Page, Site
@@ -166,3 +170,12 @@ def test_document_add_to_collection():
         collection__parent=root_collection, collection__name="new"
     )
     assert document.collection.name == "new"
+
+
+def test_get_page_facories():
+    result = wagtail_factories.get_page_factories()
+    assert result == [
+        MyTestPageFactory,
+        MyTestPageGetOrCreateFactory,
+        MyTestPageWithStreamFieldFactory,
+    ]


### PR DESCRIPTION
Dependant on #62 
Resolves #45 

`PageAutoTestCase` is an importable test case that provides an instantly high level of coverage for custom page types in a standard (non-headless) Wagtail project.

All developers need to do is:
- Import PageAutoTestCase into a module where their test runner will pick it up
- For each page type they want to test, define a PageFactory capable of creating fully functional instances

The edit-ability, serve-ability (for multiple routes), and preview-ability (for all preview modes) should then be tested for each type.

Developers can add `autotest=False` to the `Meta` class to exclude factories from these tests. For example,
where a factory is created as a 'base' for a series of subclasses, and isn't intended to be used directly. 

### What if my page types aren't a good fit?

If none of them are, simply don't import `PageAutoTestCase` into your project, and the tests should not run as part of your test suite.

If only a few page types are incompatible with `PageAutoTestCase`, you may wish to add `autotest=False` to the `Meta` class for those factories to exclude them. 

### Can I customise `PageAutoTestCase`?

`PageAutoTestCase` isn't designed to be subclassed. However, if you wanted to define something similar,, you could subclass `PageFeaturesTestCase`, which would give you access to the following assertions:

- `assertCanEditPageWithoutErrors(page: Page)`
- `assertCanRenderPageWithoutErrors(page: Page, route_path: str = "/")` 
- `assertCanPreviewPageWithoutErrors(page: Page, preview_mode: str = "")`