### PR TITLE
Make it easy to get a full list of page factories

### DIFF
--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -12,10 +12,12 @@ except ImportError:
     # Wagtail<3.0
     from wagtail.core.models import Collection, Page, Site
 
+from factory.base import FactoryMetaClass
 from factory.django import DjangoModelFactory
 from wagtail.documents import get_document_model
 
 __all__ = [
+    "get_page_factories",
     "CollectionFactory",
     "ImageFactory",
     "PageFactory",
@@ -23,6 +25,13 @@ __all__ = [
     "DocumentFactory",
 ]
 logger = logging.getLogger(__file__)
+
+
+PAGE_FACTORIES = []
+
+
+def get_page_factories():
+    return PAGE_FACTORIES
 
 
 class ParentNodeFactory(ParameteredAttribute):
@@ -115,7 +124,14 @@ class CollectionFactory(MP_NodeFactory):
         model = Collection
 
 
-class PageFactory(MP_NodeFactory):
+class PageFactoryMetaClass(FactoryMetaClass):
+    def __new__(mcs, class_name, bases, attrs):
+        new_class = super().__new__(mcs, class_name, bases, attrs)
+        PAGE_FACTORIES.append(new_class)
+        return new_class
+
+
+class PageFactory(MP_NodeFactory, metaclass=PageFactoryMetaClass):
     title = "Test page"
     slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,7 +1,11 @@
 import pytest
 
 import wagtail_factories
-from tests.testapp.factories import MyTestPageFactory, MyTestPageGetOrCreateFactory
+from tests.testapp.factories import (
+    MyTestPageFactory,
+    MyTestPageGetOrCreateFactory,
+    MyTestPageWithStreamFieldFactory,
+)
 
 try:
     from wagtail.models import Page, Site
@@ -166,3 +170,12 @@ def test_document_add_to_collection():
         collection__parent=root_collection, collection__name="new"
     )
     assert document.collection.name == "new"
+
+
+def test_get_page_facories():
+    result = wagtail_factories.get_page_factories()
+    assert result == [
+        MyTestPageFactory,
+        MyTestPageGetOrCreateFactory,
+        MyTestPageWithStreamFieldFactory,
+    ]


### PR DESCRIPTION
This is the PageFactory equivalent of `wagtail.models.get_page_models()`. It can be used to:
- Write tests that check functionality across all page types
- Write tests that check the factories themselves
- Write tests that randomise the types of page that are created