### PR TITLE
Switch to using `tox-gh-actions` in CI

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -22,7 +22,6 @@ jobs:
           - 5432:5432
 
     strategy:
-      max-parallel: 4
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         django-version: ["3.2", "4.0"]

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, Wagtail ${{ matrix.wagtail-version }}, FactoryBoy ${{ matrix.factoryboy-version }})
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -28,10 +28,10 @@ jobs:
         wagtail-version: ["2.15", "2.16", "3.0"]
         factoryboy-version: ["3.2"]
         exclude:
-          - wagtail: "2.15"
-            django: "4.0"
+          - wagtail-version: "2.15"
+            django-version: "4.0"
           - python-version: "3.7"
-            django: "4.0"
+            django-version: "4.0"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -23,19 +23,15 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version:
-          - {version: 3.7, tox: 37}
-          - {version: 3.8, tox: 38}
-          - {version: 3.9, tox: 39}
-          - {version: '3.10', tox: 310}
-        django: [32, 40]
-        wagtail: [215, 216, 30]
-        factoryboy: [32]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        django-version: ["3.2", "4.0"]
+        wagtail-version: ["2.15", "2.16", "3.0"]
+        factoryboy-version: ["3.2"]
         exclude:
-          - wagtail: 215
-            django: 40
-          - python-version: {version: 3.7, tox: 37}
-            django: 40
+          - wagtail: "2.15"
+            django: "4.0"
+          - python-version: "3.7"
+            django: "4.0"
 
     steps:
     - uses: actions/checkout@v1
@@ -45,12 +41,14 @@ jobs:
         python-version: ${{ matrix.python-version.version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade pip tox tox-gh-actions
     - name: Test with tox
       env:
         TEST_DB_NAME: wagtail_factories
         TEST_DB_USER: wagtail_factories
         TEST_DB_PASSWORD: secret
-        TOX_ENV: "py${{ matrix.python-version.tox }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}"
+        DJANGO: ${{ matrix.django-version }}
+        WAGTAIL: ${{ matrix.wagtail-version }}
+        FACTORYBOY: ${{ matrix.factoryboy-version }}
       run: |
-        tox -e $TOX_ENV
+        tox

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, Wagtail ${{ matrix.wagtail-version }}, FactoryBoy ${{ matrix.factoryboy-version }})
+    name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, Wagtail ${{ matrix.wagtail-version }}, FactoryBoy ${{ matrix.factoryboy-version }})
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ WAGTAIL =
 FACTORYBOY =
     3.2: factoryboy32
 
-
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,25 @@ envlist =
     coverage-report
     lint
 
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
+[gh-actions:env]
+DJANGO =
+    3.2: django32
+    4.0: dj40
+WAGTAIL =
+    2.15: wagtail215
+    2.16: wagtail216
+    3.0: wagtail
+FACTORYBOY =
+    3.2: factoryboy32
+
+
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test


### PR DESCRIPTION
Adds `tox-gh-actions` and cleans up the job matrix. This PR also removes the `max-parallel` restriction, which makes test runs much faster, especially when dealing with a large matrix such as the one produced by this package's workflow.

[tox-gh-actions](https://github.com/ymyzk/tox-gh-actions) is useful for making the job matrix much easier to parse, plus no need to define the Python version *and* tox env identifier.