### PR TITLE
Make ListBlockFactory return a ListValue for Wagtail >= 2.16

### DIFF
--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,12 +1,12 @@
 import pytest
+from wagtail import VERSION as wagtail_version
 
 import wagtail_factories
 from tests.testapp.factories import MyTestPageFactory, MyTestPageGetOrCreateFactory
 
-try:
+if wagtail_version >= (3, 0):
     from wagtail.models import Page, Site
-except ImportError:
-    # Wagtail<3.0
+else:
     from wagtail.core.models import Page, Site
 
 
@@ -93,6 +93,10 @@ def test_custom_page_streamfield():
     assert len(page.body) == 0
 
 
+@pytest.mark.skipif(
+    wagtail_version >= (4, 1),
+    reason="Cannot assign a naive list to a ListBlock value if using ReferenceIndex",
+)
 @pytest.mark.django_db
 def test_custom_page_streamfield_data():
     root_page = wagtail_factories.PageFactory(parent=None)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -29,7 +29,7 @@ class MyBlock(blocks.StructBlock):
     title = blocks.CharBlock(max_length=100)
     item = MyBlockItem()
     items = blocks.ListBlock(MyBlockItem)
-    image = ImageChooserBlock()
+    image = ImageChooserBlock(required=False)
 
 
 class SimpleStructBlock(blocks.StructBlock):


### PR DESCRIPTION
Fixes #65 

Wagtail 4.1 introduces the `ReferenceIndex` and functionality for tracking object usage in `StreamFields`. When Wagtail attempts to extract references from a `StreamField` that contains a `ListBlock`, it expects the value of the bound list block to be a `ListValue`.

This PR changes the `ListBlockFactory` so it returns a `ListValue` on Wagtail >= 2.16 (the version which introduced `ListValue`), and updates the tests to accomodate.

Note: there's still an issue with passing a list directly to a `StreamField` for a `ListBlock` value, e.g.:

```
MyTestPageFactory(
    parent=root_page, body=[("char_array", ["bla-1", "bla-2"])]
)
```

Wagtail won't currently "upcast" the list to a `ListValue`. As this is Wagtail behaviour it's not something we can/should fix here. If creating list values using the nested fields syntax, a `ListValue` will be created, e.g:

```
MyTestPageFactory(
    parent=root_page,
    body__0__char_array__0="bla-1",
    body__0__char_array__1="bla-2",
)
```

An alternative is to create a `ListValue` yourself:

```
MyTestPageFactory(
    parent=root_page, body=[("char_array", ListValue(ListBlock(CharBlock()), values=["bla-1", "bla-2"]))]
)
```