### PR TITLE
Remove upper bound from wagtail dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "factory-boy>=3.2",
-    "wagtail>=2.15,<5.0",
+    "wagtail>=2.15",
 ]
 
 docs_require = [


### PR DESCRIPTION
Since wagtail-factories is now a testing dependency of Wagtail itself, having an upper bound of <5.0 is blocking us from testing the now-in-development Wagtail 5.0.

There shouldn't be any risk in doing this, since if Wagtail makes a breaking change in future that breaks wagtail-factories, we (as Wagtail core devs) will need to fix wagtail-factories in order to proceed :-)