### PR TITLE
Support Wagtail 5.1, drop Python 3.7

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Unreleased
 ==========
+- Update for Wagtail 5.1
+- Drop support for Django 3.7
 
 4.1.0
 =====

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 3.14.6
 envlist =
-    py{37,38,39,310}-django32-wagtail{41,42,50}-factoryboy32
-    py{38,39,310}-django40-wagtail{41,42,50}-factoryboy32
-    py{38,39,310,311}-django41-wagtail{41,42,50}-factoryboy32
+    py{38,39,310}-django32-wagtail{41,42,50,51}-factoryboy32
+    py{38,39,310}-django40-wagtail{41,42,50,51}-factoryboy32
+    py{38,39,310,311}-django41-wagtail{41,42,50,51}-factoryboy32
     coverage-report
     lint
 
@@ -26,7 +26,7 @@ deps =
     factoryboy32: factory-boy>=3.2,<3.3
 
 [testenv:coverage-report]
-basepython = python3.7
+basepython = python3.8
 deps = coverage
 pip_pre = true
 skip_install = true
@@ -35,7 +35,7 @@ commands =
     coverage report
 
 [testenv:lint]
-basepython = python3.7
+basepython = python3.8
 deps = flake8
 commands =
     flake8 src tests setup.py


### PR DESCRIPTION
Removes support for Python 3.7
Adds support for Wagtail 5.1