### PR TITLE
Wagtail >= 5.0 upgrade

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -21,41 +21,18 @@ jobs:
           - 5432:5432
 
     strategy:
-      max-parallel: 4
       matrix:
-        python-version:
-          - {version: 3.7, tox: 37}
-          - {version: 3.8, tox: 38}
-          - {version: 3.9, tox: 39}
-          - {version: '3.10', tox: 310}
-          - {version: '3.11', tox: 311}
-        django: [32, 40, 41]
-        wagtail: [41, 42, 50]
-        factoryboy: [32]
-        exclude:
-          - python-version: {version: 3.7, tox: 37}
-            django: 40
-          - python-version: {version: 3.7, tox: 37}
-            django: 41
-          - python-version: {version: '3.11', tox: 311}
-            django: 40
-          - python-version: {version: '3.11', tox: 311}
-            django: 32
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version.version }}
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
     - name: Test with tox
-      env:
-        TEST_DB_NAME: wagtail_factories
-        TEST_DB_USER: wagtail_factories
-        TEST_DB_PASSWORD: secret
-        TOX_ENV: "py${{ matrix.python-version.tox }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-factoryboy${{ matrix.factoryboy }}"
-      run: |
-        tox -e $TOX_ENV
+      run: tox

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Unreleased
 ==========
+- Update for Wagtail 5.1
+- Drop support for Django 3.7
 
 4.1.0
 =====

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -82,3 +82,5 @@ TEMPLATES = [
 WAGTAILDOCS_SERVE_METHOD = "direct"
 
 WAGTAILADMIN_BASE_URL = "http://example.com"
+
+STATIC_URL = "/static/"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,18 @@
 [tox]
 minversion = 3.14.6
 envlist =
-    py{37,38,39,310}-django32-wagtail{41,42,50}-factoryboy32
-    py{38,39,310}-django40-wagtail{41,42,50}-factoryboy32
-    py{38,39,310,311}-django41-wagtail{41,42,50}-factoryboy32
+    py{38,39,310}-django{32,41}-wagtail{41,51,52}-factoryboy32
+    py311-django41-wagtail{41,51,52}-factoryboy32
+    py311-django42-wagtail{51,52}-factoryboy32
     coverage-report
     lint
+
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -20,13 +27,13 @@ deps =
     django32: django>=3.2,<3.3
     django40: django>=4.0,<4.1
     django41: django>=4.1,<5.0
-    wagtail41: wagtail>=4.1,<4.2
-    wagtail42: wagtail>=4.2,<5.0
-    wagtail50: wagtail>=5.0,<5.1
+    wagtail41: wagtail>=4.1,<5.0
+    wagtail51: wagtail>=5.1,<5.2
+    wagtail52: wagtail>=5.2,<5.3
     factoryboy32: factory-boy>=3.2,<3.3
 
 [testenv:coverage-report]
-basepython = python3.7
+basepython = python3.8
 deps = coverage
 pip_pre = true
 skip_install = true
@@ -35,7 +42,7 @@ commands =
     coverage report
 
 [testenv:lint]
-basepython = python3.7
+basepython = python3.8
 deps = flake8
 commands =
     flake8 src tests setup.py


### PR DESCRIPTION
## Wagtail 5.1 ([See release notes](https://docs.wagtail.org/en/stable/releases/5.1.html))

- Update testing matrix to include Wagtail 5.1
- Drop support for Python 3.7

## Wagtail 5.2 ([See release notes](https://docs.wagtail.org/en/stable/releases/5.2.html))

- Add Wagtail 5.2 to test matrix
- Drop tests for Wagtail 4.2 and 5.0 as they have reached EOL