### PR TITLE
Update for Wagtail 6.3

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Unreleased
 - Update for Wagtail 6.3
 - Add support for Python 3.13
 - Drop support for Wagtal 6.0 and 6.1
+- Drop support for Python 3.8
 
 4.2.1
 =====

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 Unreleased
 ==========
 
+- Update for Wagtail 6.3
+- Add support for Python 3.13
+- Drop support for Wagtal 6.0 and 6.1
+
 4.2.1
 =====
 - Update setup.py for PyPI compatibility

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 exclude = ["dist","build","venv",".venv",".tox",".git"]
 line-length = 88
-target-version = "py38"
+target-version = "py39"
 
 [lint]
 ignore = [

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Django",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 3.21.4
 envlist =
-    py{38,39,310,311}-django42-wagtail{52,60,61}-factoryboy{32,33}
-    py{310,311,312}-django50-wagtail{60,61}-factoryboy{32,33}
+    py{38,39,310,311}-django42-wagtail{52,62,63}-factoryboy{32,33}
+    py{310,311,312}-django50-wagtail{52,62,63}-factoryboy{32,33}
     coverage-report
     lint
 
@@ -21,8 +21,8 @@ deps =
     django42: django>=4.2,<5.0
     django50: django>=5.0,<5.1
     wagtail52: wagtail>=5.2,<6.0
-    wagtail60: wagtail>=6.0,<6.1
-    wagtail61: wagtail>=6.1,<6.2
+    wagtail62: wagtail>=6.2,<6.3
+    wagtail63: wagtail>=6.3,<6.4
     factoryboy32: factory-boy>=3.2,<3.3
     factoryboy33: factory-boy>=3.3,<3.4
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.21.4
 envlist =
-    py{38,39,310,311}-django42-wagtail{52,62}-factoryboy{32,33}
+    py{39,310,311}-django42-wagtail{52,62}-factoryboy{32,33}
     py{310,311,312}-django50-wagtail{52,62,63}-factoryboy{32,33}
     py{310,311,312,313}-django51-wagtail63-factoryboy{32,33}
     coverage-report
@@ -9,7 +9,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 minversion = 3.21.4
 envlist =
-    py{38,39,310,311}-django42-wagtail{52,62,63}-factoryboy{32,33}
+    py{38,39,310,311}-django42-wagtail{52,62}-factoryboy{32,33}
     py{310,311,312}-django50-wagtail{52,62,63}-factoryboy{32,33}
+    py{310,311,312,313}-django51-wagtail63-factoryboy{32,33}
     coverage-report
     lint
 
@@ -13,6 +14,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -20,6 +22,7 @@ extras = test
 deps =
     django42: django>=4.2,<5.0
     django50: django>=5.0,<5.1
+    django51: django>=5.1,<5.2
     wagtail52: wagtail>=5.2,<6.0
     wagtail62: wagtail>=6.2,<6.3
     wagtail63: wagtail>=6.3,<6.4


### PR DESCRIPTION
### Update package for Wagtail 6.3

This PR updates the tox testing setup to account for the Wagtail 6.3 release by:

- Adding Wagtail 6.3 to test matrix
- Adding Python 3.13 to test matrix (now supported as of Wagtail 6.3)
- Dropping no longer supported versions of Wagtail from test matrix (v6.0, v6.1)