### PR TITLE
Update fro Wagtail 6.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 minversion = 3.21.4
 envlist =
     py{39,310,311}-django42-wagtail{52,62}-factoryboy{32,33}
-    py{310,311,312}-django50-wagtail{52,62,63}-factoryboy{32,33}
-    py{310,311,312,313}-django51-wagtail63-factoryboy{32,33}
+    py{310,311,312}-django50-wagtail{52,62,63,64}-factoryboy{32,33}
+    py{310,311,312,313}-django51-wagtail{63,64}-factoryboy{32,33}
     coverage-report
     lint
 
@@ -25,6 +25,7 @@ deps =
     wagtail52: wagtail>=5.2,<6.0
     wagtail62: wagtail>=6.2,<6.3
     wagtail63: wagtail>=6.3,<6.4
+    wagtail64: wagtail>=6.4,<6.5
     factoryboy32: factory-boy>=3.2,<3.3
     factoryboy33: factory-boy>=3.3,<3.4
 


### PR DESCRIPTION
This pull request includes updates to the `setup.py` and `tox.ini` files to add support for new versions of Django and Wagtail.

Updates for testing configurations:

* Updated `envlist` to include new combinations of Django 5.0 and 5.1 with Wagtail 6.4.
* Added dependency range for Wagtail 6.4.