### PR TITLE
Add developer documentation for StreamField block factories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ dist/
 .cache
 .tox
 htmlcov
-docs/_build
+
+# Documentation builds
+docs/_build/

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Unreleased
 ==========
+- Add dev docs for StreamField factories
 
 4.3.0
 =====

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ for more examples.
 
 ``` python
 import wagtail_factories
+from wagtail import models as wt_models
+
 from . import models
 
 
@@ -63,9 +65,12 @@ class MyTestPageFactory(wagtail_factories.PageFactory):
 
 
 def test_my_page():
-    root_page = wagtail_factories.PageFactory(parent=None)
+    root_page = wt_models.Page.get_first_root_node()
+    assert root_page is not None
+
     my_page = MyTestPageFactory(
         parent=root_page,
+        title="My great page",
         body__0__carousel__items__0__label='Slide 1',
         body__0__carousel__items__0__image__image__title='Image Slide 1',
         body__0__carousel__items__1__label='Slide 2',
@@ -74,6 +79,13 @@ def test_my_page():
         body__0__carousel__items__2__image__image__title='Image Slide 3',
         body__1__news_page__page__title="News",
     )
+
+    # Defaults defined on factory classes are propagated.
+    assert my_page.body[0].value["title"] == "Carousel title"
+
+    # Parameters are propagated.
+    assert my_page.title == "My great page"
+    assert my_page.body[0].value["items"][0].value["label"] == "Slide 1"
 ```
 
 ### Using StreamBlockFactory

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,144 @@
+======================
+Architecture Overview
+======================
+
+This document provides a high-level overview of wagtail-factories' architecture and design principles.
+
+System Components
+=================
+
+wagtail-factories extends Factory Boy to create test data for Wagtail CMS models. The system consists of three main layers:
+
+**Factory Layer**
+    Core factory classes that extend Factory Boy's ``DjangoModelFactory`` for Wagtail-specific models (``PageFactory``, ``ImageFactory``, etc.)
+
+**Block Factory Layer** 
+    Specialized factories for Wagtail's block system (``StreamBlockFactory``, ``StructBlockFactory``, ``ListBlockFactory``)
+
+**Builder Layer**
+    Internal machinery that constructs complex nested structures, particularly for StreamField content
+
+Design Principles
+=================
+
+Factory Boy Integration
+-----------------------
+
+wagtail-factories is built as an extension to Factory Boy, not a replacement. This means:
+
+- All standard Factory Boy features work (``Sequence``, ``LazyAttribute``, ``SubFactory``, etc.)
+- Follows Factory Boy's patterns for extending and customizing behavior
+- Leverages Factory Boy's ``StepBuilder`` system for complex object construction
+
+Deep Object Declaration
+-----------------------
+
+The signature feature is support for "deep object declaration" syntax::
+
+    MyPageFactory(
+        body__0__carousel__items__0__label='Slide 1',
+        body__1__text_block__content='Hello world'
+    )
+
+This allows declarative construction of deeply nested StreamField content without requiring pre-built factory instances.
+
+Wagtail Block System Mapping
+-----------------------------
+
+The factory system mirrors Wagtail's block hierarchy:
+
+.. code-block:: text
+
+    Wagtail Blocks          wagtail-factories
+    =============          =================
+    StreamBlock       →    StreamBlockFactory
+    StructBlock       →    StructBlockFactory  
+    ListBlock         →    ListBlockFactory
+    CharBlock         →    CharBlockFactory
+    ImageChooserBlock →    ImageChooserBlockFactory
+
+This 1:1 mapping makes the system intuitive for developers familiar with Wagtail's block system.
+
+Key Architectural Decisions
+===========================
+
+Class-Based Factory Definition
+------------------------------
+
+StreamField factories are defined using class-based syntax that mirrors Wagtail's block definitions::
+
+    class MyStreamBlockFactory(StreamBlockFactory):
+        text = CharBlockFactory
+        image = factory.SubFactory(ImageChooserBlockFactory)
+        carousel = factory.SubFactory(CarouselBlockFactory)
+        
+        class Meta:
+            model = MyStreamBlock
+
+This approach enables nested StreamBlocks, better IDE support, and cleaner factory composition.
+
+.. note::
+
+    A legacy dict-based syntax exists::
+
+        StreamFieldFactory({'text': CharBlockFactory})
+
+    This syntax is deprecated and will be removed in a future version. It does not support nested StreamBlocks.
+
+Factory vs Builder Separation
+------------------------------
+
+**Factories** define the structure and default values:
+
+- Declare available block types
+- Set default field values  
+- Define relationships between blocks
+
+**Builders** handle runtime construction:
+
+- Parse deep object declarations
+- Validate parameter structure
+- Construct Wagtail block instances
+- Handle recursive nesting
+
+This separation allows the factory definitions to remain clean while complex construction logic lives in dedicated builder classes.
+
+Lazy Evaluation Support
+-----------------------
+
+The system preserves Factory Boy's lazy evaluation capabilities even in deeply nested structures::
+
+    class MyStructBlockFactory(StructBlockFactory):
+        title = factory.LazyAttribute(lambda obj: f"Title {obj.number}")
+        number = factory.Sequence(lambda n: n)
+
+This works correctly even when the StructBlock is nested several levels deep in a StreamField.
+
+Error Handling Philosophy
+=========================
+
+The system provides specific, actionable error messages for common mistakes:
+
+**InvalidDeclaration**
+    Malformed parameter syntax or missing required indices
+
+**DuplicateDeclaration** 
+    Multiple conflicting values for the same stream position
+
+**UnknownChildBlockFactory**
+    Reference to undefined block types
+
+This explicit error handling helps developers debug complex factory definitions.
+
+Extensibility
+=============
+
+Custom factory classes can be created by extending the provided base classes::
+
+    class CustomStructBlockFactory(StructBlockFactory):
+        # Add custom behavior, defaults, etc.
+        
+        class Meta:
+            model = MyCustomStructBlock
+
+This allows adaptation to domain-specific Wagtail block types while maintaining all the deep object declaration capabilities.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -48,7 +48,7 @@ This builds on Factory Boy's familiar relationship traversal syntax, adding supp
 
 - Block indexes (``0``, ``1``) to specify position in StreamField
 - Block type selection (``carousel``, ``text_block``)
-- Nested field paths within blocks (``items__0__label``)
+- Nested field paths within blocks (``items__0__label``, ``content``)
 
 The key difference is that Factory Boy's relationship syntax refers to static model relationships known at class definition time, while StreamField factories handle dynamic structures only known at runtime.
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,27 +1,27 @@
 ======================
-Architecture Overview
+Architecture overview
 ======================
 
 This document provides a high-level overview of wagtail-factories' architecture and design principles.
 
-System Components
+System components
 =================
 
 wagtail-factories extends Factory Boy to create test data for Wagtail CMS models. The system consists of three main layers:
 
-**Factory Layer**
+**Factory layer**
     Core factory classes that extend Factory Boy's ``DjangoModelFactory`` for Wagtail-specific models (``PageFactory``, ``ImageFactory``, etc.)
 
-**Block Factory Layer** 
+**Block factory layer**
     Specialized factories for Wagtail's block system (``StreamBlockFactory``, ``StructBlockFactory``, ``ListBlockFactory``)
 
-**Builder Layer**
+**Builder layer**
     Internal machinery that constructs complex nested structures, particularly for StreamField content. This layer handles the complex challenge of bridging Factory Boy's flat parameter structure with Wagtail's dynamic nested blocks.
 
-Design Principles
+Design principles
 =================
 
-Factory Boy Integration
+Factory Boy integration
 -----------------------
 
 wagtail-factories is built as an extension to Factory Boy, not a replacement. This means:
@@ -30,7 +30,7 @@ wagtail-factories is built as an extension to Factory Boy, not a replacement. Th
 - Follows Factory Boy's patterns for extending and customizing behavior
 - Leverages Factory Boy's ``StepBuilder`` system for complex object construction
 
-Declaration Syntax for Nested Structures
+Declaration syntax for nested structures
 ------------------------------------------
 
 wagtail-factories extends Factory Boy's existing double-underscore syntax for relationships. Where Factory Boy supports::
@@ -47,12 +47,12 @@ wagtail-factories extends this pattern to support indexed, nested StreamField st
 This builds on Factory Boy's familiar relationship traversal syntax, adding support for:
 
 - Block indexes (``0``, ``1``) to specify position in StreamField
-- Block type selection (``carousel``, ``text_block``) 
+- Block type selection (``carousel``, ``text_block``)
 - Nested field paths within blocks (``items__0__label``)
 
 The key difference is that Factory Boy's relationship syntax refers to static model relationships known at class definition time, while StreamField factories handle dynamic structures only known at runtime.
 
-Wagtail Block System Mapping
+Wagtail block system mapping
 -----------------------------
 
 The factory system mirrors Wagtail's block hierarchy:
@@ -62,17 +62,17 @@ The factory system mirrors Wagtail's block hierarchy:
     Wagtail Blocks          wagtail-factories
     =============          =================
     StreamBlock       →    StreamBlockFactory
-    StructBlock       →    StructBlockFactory  
+    StructBlock       →    StructBlockFactory
     ListBlock         →    ListBlockFactory
     CharBlock         →    CharBlockFactory
     ImageChooserBlock →    ImageChooserBlockFactory
 
 This 1:1 mapping makes the system intuitive for developers familiar with Wagtail's block system.
 
-Key Architectural Decisions
+Key architectural decisions
 ===========================
 
-Class-Based Factory Definition
+Class-based factory definition
 ------------------------------
 
 StreamField factories are defined using class-based syntax that mirrors Wagtail's block definitions::
@@ -81,7 +81,7 @@ StreamField factories are defined using class-based syntax that mirrors Wagtail'
         text = CharBlockFactory
         image = factory.SubFactory(ImageChooserBlockFactory)
         carousel = factory.SubFactory(CarouselBlockFactory)
-        
+
         class Meta:
             model = MyStreamBlock
 
@@ -95,13 +95,13 @@ This approach enables nested StreamBlocks, better IDE support, and cleaner facto
 
     This syntax is deprecated and will be removed in a future version. It does not support nested StreamBlocks.
 
-Factory vs Builder Separation
+Factory vs builder separation
 ------------------------------
 
 **Factories** define the structure and default values:
 
 - Declare available block types
-- Set default field values  
+- Set default field values
 - Define relationships between blocks
 
 **Builders** handle runtime construction:
@@ -113,7 +113,7 @@ Factory vs Builder Separation
 
 This separation allows the factory definitions to remain clean while complex construction logic lives in dedicated builder classes.
 
-Lazy Evaluation Support
+Lazy evaluation support
 -----------------------
 
 The system preserves Factory Boy's lazy evaluation capabilities even in deeply nested structures::
@@ -124,7 +124,7 @@ The system preserves Factory Boy's lazy evaluation capabilities even in deeply n
 
 This works correctly even when the StructBlock is nested several levels deep in a StreamField.
 
-Error Handling Philosophy
+Error handling philosophy
 =========================
 
 The system provides specific, actionable error messages for common mistakes:
@@ -132,7 +132,7 @@ The system provides specific, actionable error messages for common mistakes:
 **InvalidDeclaration**
     Malformed parameter syntax or missing required indices
 
-**DuplicateDeclaration** 
+**DuplicateDeclaration**
     Multiple conflicting values for the same stream position
 
 **UnknownChildBlockFactory**
@@ -147,15 +147,13 @@ Custom factory classes can be created by extending the provided base classes::
 
     class CustomStructBlockFactory(StructBlockFactory):
         # Add custom behavior, defaults, etc.
-        
+
         class Meta:
             model = MyCustomStructBlock
 
 This allows adaptation to domain-specific Wagtail block types while maintaining all the declaration syntax capabilities.
 
-Next Steps
+Next steps
 ==========
-
-**For users**: This architectural overview provides sufficient background to use wagtail-factories effectively.
 
 **For contributors**: If you need to modify or extend the StreamField factory system, see :doc:`streamfield-internals` for detailed technical implementation details including Factory Boy integration mechanisms, parameter parsing, and builder system architecture.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -9,7 +9,7 @@ System components
 
 wagtail-factories extends Factory Boy to create test data for Wagtail CMS models. The system consists of three main layers:
 
-**Factory layer**
+**Model factory layer**
     Core factory classes that extend Factory Boy's ``DjangoModelFactory`` for Wagtail-specific models (``PageFactory``, ``ImageFactory``, etc.)
 
 **Block factory layer**
@@ -85,7 +85,7 @@ StreamField factories are defined using class-based syntax that mirrors Wagtail'
         class Meta:
             model = MyStreamBlock
 
-This approach enables nested StreamBlocks, better IDE support, and cleaner factory composition.
+This approach enables nested StreamBlocks and clean, introspectable factory composition.
 
 .. note::
 
@@ -156,4 +156,8 @@ This allows adaptation to domain-specific Wagtail block types while maintaining 
 Next steps
 ==========
 
-**For contributors**: If you need to modify or extend the StreamField factory system, see :doc:`streamfield-internals` for detailed technical implementation details including Factory Boy integration mechanisms, parameter parsing, and builder system architecture.
+**For contributors**: If you need to modify or extend the StreamField factory system, see :doc:`streamfield-internals` for detailed technical implementation details, including:
+
+- Factory Boy integration mechanisms;
+- parameter parsing; and
+- builder system architecture.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -16,7 +16,7 @@ wagtail-factories extends Factory Boy to create test data for Wagtail CMS models
     Specialized factories for Wagtail's block system (``StreamBlockFactory``, ``StructBlockFactory``, ``ListBlockFactory``)
 
 **Builder Layer**
-    Internal machinery that constructs complex nested structures, particularly for StreamField content
+    Internal machinery that constructs complex nested structures, particularly for StreamField content. This layer handles the complex challenge of bridging Factory Boy's flat parameter structure with Wagtail's dynamic nested blocks.
 
 Design Principles
 =================
@@ -30,17 +30,27 @@ wagtail-factories is built as an extension to Factory Boy, not a replacement. Th
 - Follows Factory Boy's patterns for extending and customizing behavior
 - Leverages Factory Boy's ``StepBuilder`` system for complex object construction
 
-Deep Object Declaration
------------------------
+Declaration Syntax for Nested Structures
+------------------------------------------
 
-The signature feature is support for "deep object declaration" syntax::
+wagtail-factories extends Factory Boy's existing double-underscore syntax for relationships. Where Factory Boy supports::
+
+    UserFactory(profile__bio="Software developer")
+
+wagtail-factories extends this pattern to support indexed, nested StreamField structures::
 
     MyPageFactory(
         body__0__carousel__items__0__label='Slide 1',
         body__1__text_block__content='Hello world'
     )
 
-This allows declarative construction of deeply nested StreamField content without requiring pre-built factory instances.
+This builds on Factory Boy's familiar relationship traversal syntax, adding support for:
+
+- Block indexes (``0``, ``1``) to specify position in StreamField
+- Block type selection (``carousel``, ``text_block``) 
+- Nested field paths within blocks (``items__0__label``)
+
+The key difference is that Factory Boy's relationship syntax refers to static model relationships known at class definition time, while StreamField factories handle dynamic structures only known at runtime.
 
 Wagtail Block System Mapping
 -----------------------------
@@ -141,6 +151,11 @@ Custom factory classes can be created by extending the provided base classes::
         class Meta:
             model = MyCustomStructBlock
 
-This allows adaptation to domain-specific Wagtail block types while maintaining all the deep object declaration capabilities.
+This allows adaptation to domain-specific Wagtail block types while maintaining all the declaration syntax capabilities.
 
-For detailed technical information about the StreamField system internals, see :doc:`streamfield-internals`.
+Next Steps
+==========
+
+**For users**: This architectural overview provides sufficient background to use wagtail-factories effectively.
+
+**For contributors**: If you need to modify or extend the StreamField factory system, see :doc:`streamfield-internals` for detailed technical implementation details including Factory Boy integration mechanisms, parameter parsing, and builder system architecture.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -78,7 +78,7 @@ Class-based factory definition
 StreamField factories are defined using class-based syntax that mirrors Wagtail's block definitions::
 
     class MyStreamBlockFactory(StreamBlockFactory):
-        text = CharBlockFactory
+        text = factory.SubFactory(CharBlockFactory)
         image = factory.SubFactory(ImageChooserBlockFactory)
         carousel = factory.SubFactory(CarouselBlockFactory)
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -142,3 +142,5 @@ Custom factory classes can be created by extending the provided base classes::
             model = MyCustomStructBlock
 
 This allows adaptation to domain-specific Wagtail block types while maintaining all the deep object declaration capabilities.
+
+For detailed technical information about the StreamField system internals, see :doc:`streamfield-internals`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,6 +132,9 @@ html_theme_options = {
     "travis_button": True,
     "codecov_button": True,
     "analytics_id": "UA-75907833-5",
+    "show_related": True,
+    "navigation_with_keys": True,
+    "includehidden": True,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -184,6 +187,8 @@ html_static_path = ["_static"]
 # html_sidebars = {}
 html_sidebars = {
     "*": [
+        "searchbox.html",
+        "globaltoc.html",
         "sidebar-intro.html",
     ]
 }

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -21,8 +21,7 @@ Usage
 
     class MyCarouselItemFactory(wagtail_factories.StructBlockFactory):
         label = 'my-label'
-        image = factory.SubFactory(
-            wagtail_factories.ImageChooserBlockFactory)
+        image = factory.SubFactory(wagtail_factories.ImageChooserBlockFactory)
 
         class Meta:
             model = models.MyBlockItem

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -16,6 +16,8 @@ Usage
 .. code-block:: python
 
     import wagtail_factories
+    from wagtail import models as wt_models
+
     from . import models
 
 
@@ -46,9 +48,12 @@ Usage
 
 
     def test_my_page():
-        root_page = wagtail_factories.PageFactory(parent=None)
+        root_page = wt_models.Page.get_first_root_node()
+        assert root_page is not None
+
         my_page = MyTestPageFactory(
             parent=root_page,
+            title="My great page",
             body__0__carousel__items__0__label='Slide 1',
             body__0__carousel__items__0__image__image__title='Image Slide 1',
             body__0__carousel__items__1__label='Slide 2',
@@ -56,3 +61,10 @@ Usage
             body__0__carousel__items__2__label='Slide 3',
             body__0__carousel__items__2__image__image__title='Image Slide 3',
         )
+
+        # Defaults defined on factory classes are propagated.
+        assert my_page.body[0].value["title"] == "Carousel title"
+
+        # Parameters are propagated.
+        assert my_page.title == "My great page"
+        assert my_page.body[0].value["items"][0].value["label"] == "Slide 1"

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -54,4 +54,5 @@ Usage
             body__0__carousel__items__1__label='Slide 2',
             body__0__carousel__items__1__image__image__title='Image Slide 2',
             body__0__carousel__items__2__label='Slide 3',
-            body__0__carousel__items__2__image__image__title='Image Slide 3')
+            body__0__carousel__items__2__image__image__title='Image Slide 3',
+        )

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -29,8 +29,7 @@ Usage
 
     class MyCarouselFactory(wagtail_factories.StructBlockFactory):
         title = "Carousel title"
-        items = wagtail_factories.ListBlockFactory(
-            MyCarouselItemFactory)
+        items = wagtail_factories.ListBlockFactory(MyCarouselItemFactory)
 
         class Meta:
             model = models.MyCarousel

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,0 +1,59 @@
+===============
+Getting Started
+===============
+
+Installation
+============
+
+.. code-block:: shell
+
+   pip install wagtail-factories
+
+
+Usage
+=====
+
+.. code-block:: python
+
+    import wagtail_factories
+    from . import models
+
+
+    class MyCarouselItemFactory(wagtail_factories.StructBlockFactory):
+        label = 'my-label'
+        image = factory.SubFactory(
+            wagtail_factories.ImageChooserBlockFactory)
+
+        class Meta:
+            model = models.MyBlockItem
+
+
+    class MyCarouselFactory(wagtail_factories.StructBlockFactory):
+        title = "Carousel title"
+        items = wagtail_factories.ListBlockFactory(
+            MyCarouselItemFactory)
+
+        class Meta:
+            model = models.MyCarousel
+
+
+    class MyTestPageFactory(wagtail_factories.PageFactory):
+
+        body = wagtail_factories.StreamFieldFactory({
+            'carousel': MyCarouselFactory
+        })
+
+        class Meta:
+            model = models.MyTestPage
+
+
+    def test_my_page():
+        root_page = wagtail_factories.PageFactory(parent=None)
+        my_page = MyTestPageFactory(
+            parent=root_page,
+            body__0__carousel__items__0__label='Slide 1',
+            body__0__carousel__items__0__image__image__title='Image Slide 1',
+            body__0__carousel__items__1__label='Slide 2',
+            body__0__carousel__items__1__image__image__title='Image Slide 2',
+            body__0__carousel__items__2__label='Slide 3',
+            body__0__carousel__items__2__image__image__title='Image Slide 3')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ This Django app provides Factory Boy factories for the Wagtail CMS.
 
 Documentation is still in progress, but see the `tests`_ for more examples.
 
-For contributors working on wagtail-factories itself, see the :ref:`developer-documentation` section below.
+For contributors working on wagtail-factories itself, see the :doc:`architecture` and :doc:`streamfield-internals` documentation.
 
 .. _tests: https://github.com/wagtail/wagtail-factories/tree/main/tests
 
@@ -17,14 +17,5 @@ Contents
    :maxdepth: 2
 
    getting-started
-
-.. _developer-documentation:
-
-Developer Documentation
-=======================
-
-.. toctree::
-   :maxdepth: 2
-
    architecture
    streamfield-internals

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,3 +28,4 @@ Developer Documentation
 
    architecture
    streamfield-internals
+   parameter-flow-investigation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,63 +6,24 @@ This Django app provides Factory Boy factories for the Wagtail CMS.
 
 Documentation is still in progress, but see the `tests`_ for more examples.
 
+For contributors working on wagtail-factories itself, see the :ref:`developer-documentation` section below.
 
 .. _tests: https://github.com/wagtail/wagtail-factories/tree/main/tests
 
+Contents
+========
 
-Installation
-============
+.. toctree::
+   :maxdepth: 2
 
-.. code-block:: shell
+   getting-started
 
-   pip install wagtail-factories
+.. _developer-documentation:
 
+Developer Documentation
+=======================
 
+.. toctree::
+   :maxdepth: 2
 
-Usage
-=====
-.. code-block:: python
-
-
-    import wagtail_factories
-    from . import models
-
-
-    class MyCarouselItemFactory(wagtail_factories.StructBlockFactory):
-        label = 'my-label'
-        image = factory.SubFactory((
-            wagtail_factories.ImageChooserBlockFactory)
-
-        class Meta:
-            model = models.MyBlockItem
-
-
-    class MyCarouselFactory(wagtail_factories.StructBlockFactory):
-        title = "Carousel title"
-        items = wagtail_factories.ListBlockFactory(
-            MyCarouselItemFactory)
-
-        class Meta:
-            model = models.MyCarousel
-
-
-    class MyTestPageFactory(wagtail_factories.PageFactory):
-
-        body = wagtail_factories.StreamFieldFactory({
-            'carousel': MyCarouselFactory
-        })
-
-        class Meta:
-            model = models.MyTestPage
-
-
-    def test_my_page():
-        root_page = wagtail_factories.PageFactory(parent=None)
-        my_page = MyTestPageFactory(
-            parent=root_page,
-            body__0__carousel__items__0__label='Slide 1',
-            body__0__carousel__items__0__image__image__title='Image Slide 1',
-            body__0__carousel__items__1__label='Slide 2',
-            body__0__carousel__items__1__image__image__title='Image Slide 2',
-            body__0__carousel__items__2__label='Slide 3',
-            body__0__carousel__items__2__image__image__title='Image Slide 3')
+   architecture

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,3 +27,4 @@ Developer Documentation
    :maxdepth: 2
 
    architecture
+   streamfield-internals

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,4 +28,3 @@ Developer Documentation
 
    architecture
    streamfield-internals
-   parameter-flow-investigation

--- a/docs/streamfield-internals.rst
+++ b/docs/streamfield-internals.rst
@@ -5,7 +5,66 @@ StreamField internals guide
 This guide provides detailed technical documentation for contributors working on the StreamField block factory system. It covers the internal mechanisms, declaration syntax parsing, builder architecture, and block factory behavior.
 
 .. note::
-   This documentation assumes familiarity with Wagtail's block system, Factory Boy internals, and the conceptual overview in :doc:`architecture`.
+   This documentation assumes familiarity with Wagtail's block system, Factory Boy basics, and the conceptual overview in :doc:`architecture`.
+
+Factory Boy internals primer
+=============================
+
+Before diving into the StreamField system, it's helpful to understand these Factory Boy concepts that are central to the implementation:
+
+**StepBuilder**
+    Factory Boy's mechanism for constructing objects step-by-step. When you call ``MyFactory(param="value")``, Factory Boy creates a StepBuilder that processes each parameter and builds the final object. StepBuilder classes can be customized to handle complex construction logic.
+
+**DeclarationSet**
+    Factory Boy's internal storage for factory declarations. When you define ``title = "Hello"`` in a factory class, it gets stored in a DeclarationSet. The keys in this set must be valid Python identifiers, which is why wagtail-factories needs key transformation.
+
+**Strategy propagation**
+    How Factory Boy passes the build vs create decision through nested factories. When you call ``MyFactory.build()``, all nested ``SubFactory`` calls should also use ``build()``. When you call ``MyFactory.create()``, nested factories should ``create()`` and save to the database.
+
+**Lazy evaluation**
+    Factory Boy delays executing ``LazyAttribute`` and ``LazyFunction`` declarations until the object is actually being built. This allows values to depend on other fields or the current build context.
+
+**ParameteredAttribute**
+    A Factory Boy mechanism that allows factory attributes to accept parameters. ``StreamFieldFactory`` is a ``ParameteredAttribute`` that accepts block declarations and delegates to appropriate block factories.
+
+The big picture: how it all works together
+===========================================
+
+The StreamField factory system translates user declarations into Wagtail block structures:
+
+.. code-block:: text
+
+    Input:  body__0__struct_block__title="Hello"
+    Output: StreamValue with proper Wagtail block structure
+
+This translation happens in three phases:
+
+**Phase 1: Parse the declaration syntax**
+    Extract the structure from parameter names like ``body__0__struct_block__title``:
+
+    - Index: ``0`` (first item in stream)
+    - Block type: ``struct_block``
+    - Field path: ``title``
+    - Value: ``"Hello"``
+
+**Phase 2: Generate a Factory class dynamically**
+    Create a new ``StreamBlockFactory`` subclass that matches the requested structure:
+
+    .. code-block:: python
+
+        # Generated factory equivalent to:
+        class DynamicStreamFactory(StreamBlockFactory):
+            0.struct_block = SubFactory(StructBlockFactory)
+
+**Phase 3: Let Factory Boy build the objects**
+    Use Factory Boy's normal mechanisms to construct the final ``StreamValue``:
+
+    - The ``SubFactory`` creates the ``StructBlockFactory``
+    - Parameters like ``title="Hello"`` get passed to the struct factory
+    - Factory Boy handles lazy evaluation, strategy propagation, etc.
+    - The final result is a proper Wagtail ``StreamValue`` object
+
+This approach preserves Factory Boy's features while handling the nested structure that Wagtail StreamBlocks require.
 
 Implementation background
 ==========================
@@ -48,7 +107,7 @@ Declaration parsing occurs in ``StreamBlockStepBuilder.get_block_declarations()`
     def get_block_declarations(self, factory_meta, extras):
         indexed_block_names = {}  # Maps index -> block_name
         extra_declarations = {}   # Maps transformed keys -> values
-        
+
         for k, v in extras.items():
             if k.isdigit():
                 # Handle: body__0="struct_block"
@@ -66,7 +125,7 @@ Key transformation process
 Parameters like ``body__0__struct_block__title="foo"`` undergo this transformation:
 
 1. **Split**: ``["0", "struct_block", "title"]``
-2. **Extract**: index=0, name="struct_block", params=["title"]  
+2. **Extract**: index=0, name="struct_block", params=["title"]
 3. **Transform**: ``"0.struct_block__title"`` (note the dot separator)
 4. **Store**: ``extra_declarations["0.struct_block__title"] = "foo"``
 
@@ -85,7 +144,7 @@ Complex declaration examples
 
 Represents:
 - StreamField ``body``
-- Index 0: StructBlock ``struct_block``  
+- Index 0: StructBlock ``struct_block``
 - Field ``inner_stream``: Nested StreamBlock
 - Index 1: CharBlock with value "text"
 
@@ -95,7 +154,7 @@ Represents:
 
 Parameter breakdown:
 - First ``0``: StreamField index
-- ``list_block``: Block name  
+- ``list_block``: Block name
 - Second ``0``: ListBlock item index
 - Third ``0``: Inner StreamBlock index
 - ``struct_block__title``: Nested structure
@@ -107,13 +166,13 @@ The builder system is the core machinery that transforms parsed declarations int
 
 .. important::
    **Why custom builders?**
-   
+
    Factory Boy's built-in StepBuilder assumes static factory declarations known at class definition time. StreamField factories need to handle dynamic structures where the required blocks and their indexes are only known when the factory is called.
 
    Custom builders solve this by:
 
    - Parsing indexed parameter syntax that Factory Boy doesn't understand
-   - Dynamically generating factory classes based on user parameters  
+   - Dynamically generating factory classes based on user parameters
    - Preserving Factory Boy features like lazy evaluation and strategy propagation
 
 StreamBlockStepBuilder construction flow
@@ -164,10 +223,10 @@ Example flow: ``body__0__struct_block__title="Hello"``
 -------------------------------------------------------
 
 1. **Entry**: ``StreamFieldFactory.evaluate()`` receives parameters
-2. **Delegation**: Parameters passed to ``StreamBlockFactory(**extra)``  
+2. **Delegation**: Parameters passed to ``StreamBlockFactory(**extra)``
 3. **Builder creation**: ``StreamBlockStepBuilder(factory_meta, extras, strategy)``
-4. **Declaration parsing**: 
-   
+4. **Declaration parsing**:
+
    - Extract: index=0, name="struct_block", params=["title"]
    - Transform: ``"0.struct_block__title": "Hello"``
 
@@ -212,7 +271,7 @@ StreamBlockFactory
         for indexed_block_name, value in kwargs.items():
             i, name = indexed_block_name.split(".")
             stream_data[int(i)] = (name, value)
-        
+
         # Convert to StreamValue if block definition available
         block_def = cls._meta.get_block_definition()
         if block_def is None:
@@ -280,7 +339,7 @@ StreamFieldFactory (ParameteredAttribute)
     body = StreamFieldFactory({
         "block_name": BlockFactory,
     })
-    
+
     # Class-based (recommended)
     body = StreamFieldFactory(MyStreamBlockFactory)
 
@@ -291,10 +350,10 @@ The system provides comprehensive error handling with specific exception types a
 
 .. important::
    **Why extensive validation?**
-   
+
    StreamField factories have complex requirements that Factory Boy doesn't naturally enforce:
 
-   - **Sequential indexes**: Wagtail StreamBlocks require indexes 0, 1, 2... without gaps  
+   - **Sequential indexes**: Wagtail StreamBlocks require indexes 0, 1, 2... without gaps
    - **Consistent block names**: The same index can't refer to different block types
    - **Valid block references**: All referenced block factories must be defined
 
@@ -328,3 +387,105 @@ Validation rules
 
     if v not in factory_meta.base_declarations:
         raise UnknownChildBlockFactory(f"No factory defined for block '{v}'")
+
+Extending the system
+=====================
+
+Adding support for new block types
+-----------------------------------
+
+To add support for a new Wagtail block type, follow this pattern:
+
+**1. Create a factory class extending the appropriate base**:
+
+.. code-block:: python
+
+    class MyCustomBlockFactory(StructBlockFactory):
+        # Define default field values
+        title = "Default Title"
+        content = factory.LazyAttribute(lambda obj: f"Generated content {obj.id}")
+
+        class Meta:
+            model = MyCustomBlock
+
+**2. For blocks requiring custom construction logic**:
+
+.. code-block:: python
+
+    class ComplexBlockFactory(factory.Factory):
+        class Meta:
+            model = ComplexBlock
+
+        @classmethod
+        def _create(cls, model_class, **kwargs):
+            # Custom construction logic here
+            return model_class(**processed_kwargs)
+
+**3. For blocks that need special StepBuilder handling**:
+
+.. code-block:: python
+
+    class CustomBlockStepBuilder(BaseBlockStepBuilder):
+        def evaluate(self, instance, step, extra):
+            # Custom parameter processing
+            processed_params = self.process_custom_syntax(extra)
+            return super().evaluate(instance, step, processed_params)
+
+    class CustomBlockFactory(factory.Factory):
+        _BUILDER_CLASS = CustomBlockStepBuilder
+
+        class Meta:
+            model = CustomBlock
+
+Integration patterns
+--------------------
+
+**Adding to existing StreamBlock factories**:
+
+.. code-block:: python
+
+    class MyStreamBlockFactory(StreamBlockFactory):
+        text = CharBlockFactory
+        image = factory.SubFactory(ImageChooserBlockFactory)
+        custom = factory.SubFactory(MyCustomBlockFactory)  # Add your custom block
+
+        class Meta:
+            model = MyStreamBlock
+
+**Testing new block factories**:
+
+.. code-block:: python
+
+    def test_custom_block_factory():
+        # Test basic construction
+        block_value = MyCustomBlockFactory()
+        assert isinstance(block_value, MyCustomBlock)
+
+        # Test parameter handling
+        block_value = MyCustomBlockFactory(title="Test Title")
+        assert block_value['title'] == "Test Title"
+
+        # Test in StreamField context
+        page = MyPageFactory(body__0="custom", body__0__custom__title="Stream Title")
+        assert page.body[0].value['title'] == "Stream Title"
+
+Glossary
+=========
+
+**Block definition propagation**
+    The process of passing Wagtail block definitions through nested factory calls so that anonymous StreamBlocks can construct proper ``StreamValue`` objects.
+
+**Deep object declaration**
+    The syntax that allows specifying nested structure parameters like ``body__0__struct_block__title="Hello"`` in a single factory call.
+
+**Dynamic factory generation**
+    The core technique where ``StreamBlockStepBuilder`` creates new factory classes at runtime based on user-requested block combinations.
+
+**Key transformation**
+    Converting parameter names like ``body__0__struct_block__title`` into Factory Boy-compatible keys like ``0.struct_block__title``.
+
+**Sequential index validation**
+    Ensuring that StreamField indexes are consecutive starting from 0, since Wagtail requires this structure.
+
+**Strategy propagation**
+    Factory Boy's mechanism for ensuring that build/create decisions flow correctly through nested ``SubFactory`` calls.

--- a/docs/streamfield-internals.rst
+++ b/docs/streamfield-internals.rst
@@ -1,0 +1,330 @@
+==============================
+StreamField internals guide
+==============================
+
+This guide provides detailed technical documentation for contributors working on the StreamField block factory system. It covers the internal mechanisms, declaration syntax parsing, builder architecture, and block factory behavior.
+
+.. note::
+   This documentation assumes familiarity with Wagtail's block system, Factory Boy internals, and the conceptual overview in :doc:`architecture`.
+
+Implementation background
+==========================
+
+The StreamField factory system is complex because it bridges two incompatible paradigms: Factory Boy's flat parameter structure and Wagtail's dynamic nested blocks.
+
+Factory Boy expects parameters like ``title="Hello"`` that map directly to object attributes. StreamField factories need to handle ``body__0__struct_block__title="Hello"`` - indexed, nested declarations that describe dynamic structures unknown until runtime.
+
+Early implementations bypassed Factory Boy entirely but lost features like lazy evaluation and build/create strategies. The current approach generates Factory classes dynamically based on user parameters, preserving Factory Boy integration while handling the structural complexity.
+
+Declaration syntax and parsing
+===============================
+
+The StreamField factory system supports a sophisticated declaration syntax that allows deep nesting and precise control over block construction. Understanding how this syntax is parsed is crucial for maintaining and extending the system.
+
+Core syntax patterns
+---------------------
+
+The system recognizes two primary declaration patterns:
+
+**Parametric declarations**::
+
+    body__0__struct_block__title="Hello World"
+
+This creates a ``struct_block`` at index 0 with its ``title`` field set to "Hello World".
+
+**Block type declarations**::
+
+    body__0="struct_block"
+
+This creates a ``struct_block`` at index 0 using factory defaults.
+
+Deep declaration parsing
+-------------------------
+
+Declaration parsing occurs in ``StreamBlockStepBuilder.get_block_declarations()``:
+
+.. code-block:: python
+
+    def get_block_declarations(self, factory_meta, extras):
+        indexed_block_names = {}  # Maps index -> block_name
+        extra_declarations = {}   # Maps transformed keys -> values
+        
+        for k, v in extras.items():
+            if k.isdigit():
+                # Handle: body__0="struct_block"
+                indexed_block_names[int(k)] = v
+            else:
+                # Handle: body__0__struct_block__title="foo"
+                i, name, *params = k.split("__", maxsplit=2)
+                indexed_block_names[int(i)] = name
+                transformed_key = self.reconstruct_key(i, name, params)
+                extra_declarations[transformed_key] = v
+
+Key transformation process
+--------------------------
+
+Parameters like ``body__0__struct_block__title="foo"`` undergo this transformation:
+
+1. **Split**: ``["0", "struct_block", "title"]``
+2. **Extract**: index=0, name="struct_block", params=["title"]  
+3. **Transform**: ``"0.struct_block__title"`` (note the dot separator)
+4. **Store**: ``extra_declarations["0.struct_block__title"] = "foo"``
+
+The dot-separated format (``0.struct_block__title``) is crucial because:
+
+- It creates unique, hashable keys for Factory Boy's DeclarationSet
+- The dot prevents Factory Boy from treating "0" as an unknown declaration
+- It maintains hierarchical structure needed for nested construction
+
+Complex declaration examples
+-----------------------------
+
+**Deep nesting**::
+
+    body__0__struct_block__inner_stream__1__char_block="text"
+
+Represents:
+- StreamField ``body``
+- Index 0: StructBlock ``struct_block``  
+- Field ``inner_stream``: Nested StreamBlock
+- Index 1: CharBlock with value "text"
+
+**ListBlock with StreamBlock items**::
+
+    body__0__list_block__0__0__struct_block__title="foo"
+
+Parameter breakdown:
+- First ``0``: StreamField index
+- ``list_block``: Block name  
+- Second ``0``: ListBlock item index
+- Third ``0``: Inner StreamBlock index
+- ``struct_block__title``: Nested structure
+
+Builder system architecture
+============================
+
+The builder system is the core machinery that transforms parsed declarations into Wagtail block structures.
+
+.. important::
+   **Why custom builders?**
+   
+   Factory Boy's built-in StepBuilder assumes static factory declarations known at class definition time. StreamField factories need to handle dynamic structures where the required blocks and their indexes are only known when the factory is called.
+
+   Custom builders solve this by:
+
+   - Parsing indexed parameter syntax that Factory Boy doesn't understand
+   - Dynamically generating factory classes based on user parameters  
+   - Preserving Factory Boy features like lazy evaluation and strategy propagation
+
+StreamBlockStepBuilder construction flow
+----------------------------------------
+
+**1. Initialization phase**:
+
+.. code-block:: python
+
+    def __init__(self, factory_meta, extras, strategy):
+        indexed_block_names, extra_declarations = self.get_block_declarations(factory_meta, extras)
+        new_factory_class = self.create_factory_class(factory_meta, indexed_block_names)
+        super().__init__(new_factory_class._meta, extra_declarations, strategy)
+
+**2. Dynamic factory generation**:
+
+- Creates a new ``StreamBlockFactory`` subclass at runtime
+- Adds declarations for each requested block: ``{f"{index}.{name}": declared_value}``
+- Example: ``{"0.struct_block": SubFactory(StructBlockFactory)}``
+
+**3. Recursive construction**:
+
+- Factory Boy handles the actual object construction
+- Each sub-factory gets its own builder with filtered parameters
+- Deep nesting is supported through recursive ``SubFactory`` calls
+
+Block definition propagation
+-----------------------------
+
+A sophisticated system ensures nested StreamBlocks have proper block definitions:
+
+.. code-block:: python
+
+    if block_def is not None and isinstance(declared_value, SubFactory):
+        child_def = block_def.child_blocks[name]
+        if isinstance(child_def, blocks.ListBlock):
+            child_def = child_def.child_block  # Special handling for ListBlock
+        declared_value.get_factory()._meta.block_def = child_def
+
+This allows anonymous StreamBlocks (declared inline) to construct proper ``StreamValue`` objects.
+
+Parameter flow through the system
+==================================
+
+Understanding how parameters flow through the system is essential for debugging and extending functionality.
+
+Example flow: ``body__0__struct_block__title="Hello"``
+-------------------------------------------------------
+
+1. **Entry**: ``StreamFieldFactory.evaluate()`` receives parameters
+2. **Delegation**: Parameters passed to ``StreamBlockFactory(**extra)``  
+3. **Builder creation**: ``StreamBlockStepBuilder(factory_meta, extras, strategy)``
+4. **Declaration parsing**: 
+   
+   - Extract: index=0, name="struct_block", params=["title"]
+   - Transform: ``"0.struct_block__title": "Hello"``
+
+5. **Factory generation**: Create dynamic factory with ``"0.struct_block": SubFactory(...)``
+6. **Construction**: Factory Boy builds the structure recursively
+7. **Value assembly**: Final ``StreamValue`` with proper Wagtail block structure
+
+Complex flow example
+---------------------
+
+For ``body__0__struct__inner_stream__1__char_block="text"``:
+
+1. First-level parsing creates ``struct`` at index 0
+2. ``inner_stream__1__char_block="text"`` passed to StructBlockFactory
+3. StructBlockFactory creates inner StreamFieldFactory for ``inner_stream``
+4. Inner factory parses ``1__char_block="text"``
+5. Recursive construction builds the full hierarchy
+
+Block factory behavior
+=======================
+
+Each block factory type has specific behavior patterns and construction logic.
+
+StreamBlockFactory
+-------------------
+
+**Primary role**: Constructs StreamValue objects from indexed block declarations
+
+**Key methods**:
+
+- ``_construct_stream()``: Creates the final StreamValue from parsed data
+- ``_generate()``: Orchestrates the building process via StreamBlockStepBuilder
+
+**Stream construction logic**:
+
+.. code-block:: python
+
+    def _construct_stream(cls, block_class, *args, **kwargs):
+        # Parse indexed declarations like "0.struct_block": value
+        stream_length = max(map(get_index, kwargs.keys())) + 1 if kwargs else 0
+        stream_data = [None] * stream_length
+        for indexed_block_name, value in kwargs.items():
+            i, name = indexed_block_name.split(".")
+            stream_data[int(i)] = (name, value)
+        
+        # Convert to StreamValue if block definition available
+        block_def = cls._meta.get_block_definition()
+        if block_def is None:
+            return stream_data  # Legacy format
+        return blocks.StreamValue(block_def, stream_data)
+
+StructBlockFactory
+------------------
+
+**Primary role**: Creates StructValue objects with named field access
+
+**Construction process**:
+
+.. code-block:: python
+
+    def _construct_struct_value(cls, block_class, params):
+        return block_class._meta_class.value_class(
+            block_class(),
+            list(params.items()),
+        )
+
+**Declaration patterns**:
+
+- ``title="Hello"`` - Direct field assignment
+- ``nested_struct__field="value"`` - Nested structure access
+
+ListBlockFactory
+-----------------
+
+**Primary role**: Handles ListBlock construction with indexed item access
+
+**Declaration patterns**:
+
+- ``items__0__label="foo"`` - Set label of first item
+- ``items__1="value"`` - Set value of second item directly
+
+**Construction process**:
+
+.. code-block:: python
+
+    def evaluate(self, instance, step, extra):
+        result = defaultdict(dict)
+        for key, value in extra.items():
+            if key.isdigit():
+                result[int(key)]["value"] = value
+            else:
+                prefix, label = key.split("__", maxsplit=1)
+                result[int(prefix)][label] = value
+        # Build each item and create ListValue
+
+StreamFieldFactory (ParameteredAttribute)
+------------------------------------------
+
+**Primary role**: Entry point that bridges Factory Boy declarations to StreamBlock construction
+
+**Key features**:
+
+- Supports both dict-based and class-based StreamBlock factory definitions
+- Delegates to a ``StreamBlockFactory`` subclass for actual construction
+- Handles two initialization patterns:
+
+.. code-block:: python
+
+    # Dict-based (deprecated)
+    body = StreamFieldFactory({
+        "block_name": BlockFactory,
+    })
+    
+    # Class-based (recommended)
+    body = StreamFieldFactory(MyStreamBlockFactory)
+
+Error handling and validation
+==============================
+
+The system provides comprehensive error handling with specific exception types and validation rules.
+
+.. important::
+   **Why extensive validation?**
+   
+   StreamField factories have complex requirements that Factory Boy doesn't naturally enforce:
+
+   - **Sequential indexes**: Wagtail StreamBlocks require indexes 0, 1, 2... without gaps  
+   - **Consistent block names**: The same index can't refer to different block types
+   - **Valid block references**: All referenced block factories must be defined
+
+   Without upfront validation, users get confusing errors deep in the Wagtail/Factory Boy stack. Custom validation provides clear error messages that point directly to the problem.
+
+Validation rules
+----------------
+
+**Sequential index validation**:
+
+.. code-block:: python
+
+    def validate_block_indexes_sequential(self, indexed_block_names, factory_meta):
+        indexes = sorted(indexed_block_names.keys())
+        for declared, expected in zip_longest(indexes, range(max(indexes) + 1)):
+            if declared != expected:
+                raise InvalidDeclaration(f"missing required index {expected}")
+
+**Duplicate detection**:
+
+.. code-block:: python
+
+    if key in indexed_block_names and indexed_block_names[key] != name:
+        raise DuplicateDeclaration(
+            f"Multiple declarations for index {key} (got {name}, already have {indexed_block_names[key]})"
+        )
+
+**Block type validation**:
+
+.. code-block:: python
+
+    if v not in factory_meta.base_declarations:
+        raise UnknownChildBlockFactory(f"No factory defined for block '{v}'")


### PR DESCRIPTION
## Summary

Addresses #103 

- Add comprehensive developer documentation for StreamField block factories
- Includes both architecture overview and detailed internals guide
- Restructure documentation with unified navigation and improved Sphinx build

## Background

The StreamField factory system is complex, involving multiple layers (factories, builders, deep object declaration syntax) that weren't well documented. This made it difficult for new contributors to understand and extend the system.

## Documentation Added

**Architecture Overview** (`docs/architecture.rst`):
- High-level system components and design principles
- Factory Boy integration approach
- Key architectural decisions and extensibility patterns

**StreamField Internals Guide** (`docs/streamfield-internals.rst`):
- Factory Boy integration details and declaration timing
- Three-phase parameter transformation process
- Builder system architecture and parameter flow
- Block factory behavior and configuration system
- Error handling, validation, and extension guide

**Documentation Structure**:
- Unified navigation so all pages are accessible from anywhere
- Fixed Sphinx build warnings and improved cross-references
- Created dedicated getting-started page

## Target Audience

- New contributors wanting to understand the codebase
- Existing maintainers who need to recall system design
- Developers extending the factory system with custom block types

## Test Plan
- [x] Documentation builds successfully with Sphinx
- [x] Navigation works between all pages
- [x] Code examples are syntactically correct
- [x] Technical details verified against actual codebase behavior