### PR TITLE
Wagtail 72 maintenance

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ tests_require = [
     "pytest-cov==6.2.1",
     "coverage==7.10.3",
     "ruff==0.12.8",
+    "tox==4.32.0",
 ]
 
 with open("README.md") as fh:

--- a/setup.py
+++ b/setup.py
@@ -3,20 +3,20 @@ import re
 from setuptools import find_packages, setup
 
 install_requires = [
-    "factory-boy>=3.2,<4",
-    "wagtail>=6.3",
+    "factory-boy>=3.3,<4",
+    "wagtail>=7.0",
 ]
 
 docs_require = [
-    "sphinx>=7.3.7",
+    "sphinx>=8.2.3",
 ]
 
 tests_require = [
-    "pytest==8.4.1",
+    "pytest==9.0.0",
     "pytest-django==4.11.1",
-    "pytest-cov==6.2.1",
-    "coverage==7.10.3",
-    "ruff==0.12.8",
+    "pytest-cov==7.0.0",
+    "coverage==7.11.3",
+    "ruff==0.14.4",
     "tox==4.32.0",
 ]
 
@@ -51,11 +51,11 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Django",
@@ -63,7 +63,6 @@ setup(
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 6",
         "Framework :: Wagtail :: 7",
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 from setuptools import find_packages, setup
 
 install_requires = [
-    "factory-boy>=3.3,<4",
+    "factory-boy>=3.2,<4",
     "wagtail>=6.3",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "factory-boy>=3.3,<4",
-    "wagtail>=7.0",
+    "wagtail>=6.3",
 ]
 
 docs_require = [
@@ -63,6 +63,7 @@ setup(
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Framework :: Wagtail",
+        "Framework :: Wagtail :: 6",
         "Framework :: Wagtail :: 7",
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,21 @@
 [tox]
-minversion = 3.21.4
+minversion = 4.32.0
+skip_missing_interpreters = true
 envlist =
-    py{39,310,311,312}-django42-wagtail{63,70,71}-factoryboy{32,33}
-    py{310,311,312,313}-django{51,52}-wagtail{63,70,71}-factoryboy{32,33}
+    py{310,311,312}-django42-wagtail{70,71,72}-factoryboy{33}
+    py{310,311,312,313}-django{51,52}-wagtail{70,71,72}-factoryboy{33}
+    py314-django52-wagtail72-factoryboy33
 
     coverage-report
     lint
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -22,10 +24,9 @@ deps =
     django42: django>=4.2,<5.0
     django51: django>=5.1,<5.2
     django52: django>=5.2,<5.3
-    wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
     wagtail71: wagtail>=7.1,<7.2
-    factoryboy32: factory-boy>=3.2,<3.3
+    wagtail72: wagtail>=7.2,<7.3
     factoryboy33: factory-boy>=3.3,<3.4
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ deps =
     wagtail70: wagtail>=7.0,<7.1
     wagtail71: wagtail>=7.1,<7.2
     wagtail72: wagtail>=7.2,<7.3
-    factoryboy32: factory-boy>=3.2,<3.4
+    factoryboy32: factory-boy>=3.2,<3.3
+    factoryboy33: factory-boy>=3.3,<3.4
 
 [testenv:coverage-report]
 basepython = python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     wagtail70: wagtail>=7.0,<7.1
     wagtail71: wagtail>=7.1,<7.2
     wagtail72: wagtail>=7.2,<7.3
-    factoryboy33: factory-boy>=3.3,<3.4
+    factoryboy32: factory-boy>=3.2,<3.4
 
 [testenv:coverage-report]
 basepython = python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 minversion = 4.32.0
 skip_missing_interpreters = true
 envlist =
-    py{310,311,312}-django42-wagtail{63,70,71,72}-factoryboy{32}
-    py{310,311,312,313}-django{51,52}-wagtail{63,70,71,72}-factoryboy{33}
+    py{310,311,312}-django42-wagtail{63,70,71,72}-factoryboy32
+    py{310,311,312,313}-django{51,52}-wagtail{63,70,71,72}-factoryboy33
     py314-django52-wagtail72-factoryboy33
 
     coverage-report

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 minversion = 4.32.0
 skip_missing_interpreters = true
 envlist =
-    py{310,311,312}-django42-wagtail{70,71,72}-factoryboy{33}
-    py{310,311,312,313}-django{51,52}-wagtail{70,71,72}-factoryboy{33}
+    py{310,311,312}-django42-wagtail{63,70,71,72}-factoryboy{33}
+    py{310,311,312,313}-django{51,52}-wagtail{63,70,71,72}-factoryboy{33}
     py314-django52-wagtail72-factoryboy33
 
     coverage-report
@@ -24,6 +24,7 @@ deps =
     django42: django>=4.2,<5.0
     django51: django>=5.1,<5.2
     django52: django>=5.2,<5.3
+    wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
     wagtail71: wagtail>=7.1,<7.2
     wagtail72: wagtail>=7.2,<7.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.32.0
 skip_missing_interpreters = true
 envlist =
-    py{310,311,312}-django42-wagtail{63,70,71,72}-factoryboy{33}
+    py{310,311,312}-django42-wagtail{63,70,71,72}-factoryboy{32}
     py{310,311,312,313}-django{51,52}-wagtail{63,70,71,72}-factoryboy{33}
     py314-django52-wagtail72-factoryboy33
 


### PR DESCRIPTION
This pull request updates the project's Python, Wagtail, and dependency support to newer versions, and improves compatibility with the latest tooling. It also removes support for older versions and streamlines the test matrix.

**Dependency and compatibility updates:**

* Updated `setup.py` dependencies to support newer versions: `factory-boy` (>=3.2), `wagtail` (>=6.3), `sphinx` (>=8.2.3), `pytest` (==9.0.0), `pytest-cov` (==7.0.0), `coverage` (==7.11.3), and `ruff` (==0.14.4). Added `tox` (==4.32.0) to test requirements.
* Updated `tox.ini` to require `tox` >= 4.32.0 and added `skip_missing_interpreters = true` for better environment handling.
* Updated dependency groups in `tox.ini` to add support for Wagtail 7.2 and factory-boy 3.3.

**Python and framework version support:**

* Added Python 3.14 support throughout the workflow, `setup.py` classifiers, and `tox.ini` environments; removed Python 3.9 support.
* Updated `setup.py` classifiers to reflect support for Wagtail 7 and Python 3.14, and removed references to deprecated versions.

**Test matrix and environment improvements:**

* Streamlined the `tox.ini` test matrix to focus on supported Python, Django, Wagtail, and factory-boy combinations, including new entries for Python 3.14 and Wagtail 7.2.